### PR TITLE
sharp 0.32.6 이전 버전에서 보안 취약점이 발견되어 0.32.6 버전으로 업데이트 합니다

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-quill": "^2.0.0",
-    "sharp": "^0.32.5",
+    "sharp": "^0.32.6",
     "typescript": "5.1.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2490,10 +2490,10 @@ semver@^7.3.5, semver@^7.5.4:
   dependencies:
     lru-cache "^6.0.0"
 
-sharp@^0.32.5:
-  version "0.32.5"
-  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.32.5.tgz#9ddc78ead6446094f51e50355a2d4ec6e7220cd4"
-  integrity sha512-0dap3iysgDkNaPOaOL4X/0akdu0ma62GcdC2NBQ+93eqpePdDdr2/LM0sFdDSMmN7yS+odyZtPsb7tx/cYBKnQ==
+sharp@^0.32.6:
+  version "0.32.6"
+  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.32.6.tgz#6ad30c0b7cd910df65d5f355f774aa4fce45732a"
+  integrity sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==
   dependencies:
     color "^4.2.3"
     detect-libc "^2.0.2"


### PR DESCRIPTION
## 배경
- sharp 패키지의 보안 취약점이 발견되어 최신 버전으로 업데이트 합니다.
- https://github.com/Genithlabs/Memorial/security/dependabot/5

## 작업내용
- 기존 sharp 패키지의 버전을 0.32.6 버전으로 업데이트 합니다.

## 테스트방법
- yarn install 로 next auth 패키지를 설치합니다.
- yarn dev 명령어로 로컬 서버를 실행합니다.
- 정상적으로 사용자 페이지가 나타나는지 확인합니다.

## 리뷰노트
- sharp는 WebP 이미지를 디코드하는 데 libwebp를 사용합니다.
- 0.32.6 버전 이전의 sharp는 GHSA-j7hp-h8jx-5ppr에 의해 고위험도로 분류된 보안 취약점에 노출되어 있습니다.

## 스크린샷
![스크린샷 2024-01-28 오후 5 05 38](https://github.com/Genithlabs/Memorial/assets/15684441/543f2e75-22a1-4d5f-91f3-c2330da7643e)


