### PR TITLE
회원 가입 API를 연결합니다.

### DIFF
--- a/components/SignUp.tsx
+++ b/components/SignUp.tsx
@@ -7,9 +7,8 @@ import Grid from '@mui/material/Grid';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import Checkbox from '@mui/material/Checkbox';
 import NextLink from 'next/link';
+import { useRouter } from 'next/router';
 
 function Copyright() {
 	return (
@@ -25,16 +24,47 @@ function Copyright() {
 }
 
 export default function SignUp() {
-	const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+	const router = useRouter();
+	const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
 		const data = new FormData(event.currentTarget);
-		console.log({
+		const url = `${process.env.NEXT_PUBLIC_API_URL}/api/user/register`;
+
+		const formData = {
 			user_id: data.get('user_id'),
 			user_name: data.get('user_name'),
 			email: data.get('email'),
 			user_password: data.get('user_password'),
 			re_password: data.get('re_user_password'),
-		});
+		};
+
+		// 유효성 검사
+		if (!formData.user_id || !formData.user_name || !formData.email || !formData.user_password || !formData.re_password) {
+			alert('모든 값을 입력해주세요.');
+			return;
+		}
+
+		if (formData.user_password !== formData.re_password) {
+			alert('비밀번호가 일치하지 않습니다.');
+			return;
+		}
+
+		try {
+			const response = await fetch(url, {
+				method: 'POST',
+				headers: {'Content-Type': 'application/json'},
+				body: JSON.stringify(formData),
+			});
+
+			if (response.ok) {
+				router.push('/signin');
+			} else {
+				const result = await response.json();
+				alert('회원 가입 실패: ' + result.error[0]);
+			}
+		} catch (error) {
+			alert('회원 가입 중 에러 발생: ' + error);
+		}
 	};
 
 	return (

--- a/components/SignUp.tsx
+++ b/components/SignUp.tsx
@@ -29,8 +29,11 @@ export default function SignUp() {
 		event.preventDefault();
 		const data = new FormData(event.currentTarget);
 		console.log({
+			user_id: data.get('user_id'),
+			user_name: data.get('user_name'),
 			email: data.get('email'),
-			password: data.get('password'),
+			user_password: data.get('user_password'),
+			re_password: data.get('re_user_password'),
 		});
 	};
 
@@ -49,29 +52,29 @@ export default function SignUp() {
 						<LockOutlinedIcon />
 					</Avatar>
 					<Typography component="h1" variant="h5">
-						Sign Up
+						회원 가입
 					</Typography>
 					<Box component="form" noValidate onSubmit={handleSubmit} sx={{ mt: 3 }}>
 						<Grid container spacing={2}>
-							<Grid item xs={12} sm={6}>
+							<Grid item xs={12}>
 								<TextField
 									autoComplete="given-name"
-									name="firstName"
+									name="user_id"
 									required
 									fullWidth
-									id="firstName"
-									label="First Name"
+									id="user_id"
+									label="ID"
 									autoFocus
 								/>
 							</Grid>
-							<Grid item xs={12} sm={6}>
+							<Grid item xs={12}>
 								<TextField
+									autoComplete="given-name"
+									name="user_name"
 									required
 									fullWidth
-									id="lastName"
-									label="Last Name"
-									name="lastName"
-									autoComplete="family-name"
+									id="user_name"
+									label="이름"
 								/>
 							</Grid>
 							<Grid item xs={12}>
@@ -79,26 +82,28 @@ export default function SignUp() {
 									required
 									fullWidth
 									id="email"
-									label="Email Address"
+									label="Email"
 									name="email"
-									autoComplete="email"
 								/>
 							</Grid>
 							<Grid item xs={12}>
 								<TextField
 									required
 									fullWidth
-									name="password"
-									label="Password"
+									name="user_password"
+									label="비밀번호"
 									type="password"
-									id="password"
-									autoComplete="new-password"
+									id="user_password"
 								/>
 							</Grid>
 							<Grid item xs={12}>
-								<FormControlLabel
-									control={<Checkbox value="allowExtraEmails" color="primary" />}
-									label="I want to receive inspiration, marketing promotions and updates via email."
+								<TextField
+									required
+									fullWidth
+									name="re_user_password"
+									label="비밀번호 재입력"
+									type="password"
+									id="re_user_password"
 								/>
 							</Grid>
 						</Grid>
@@ -108,13 +113,13 @@ export default function SignUp() {
 							variant="contained"
 							sx={{ mt: 3, mb: 2 }}
 						>
-							Sign Up
+							확인
 						</Button>
 						<Grid container justifyContent="flex-end">
 							<Grid item>
 								<NextLink href="/signin" passHref>
 									<MUILink variant="body2" component={"button"}>
-										Already have an account? Sign in
+										이미 회원 이신가요?
 									</MUILink>
 								</NextLink>
 							</Grid>


### PR DESCRIPTION
## 배경
- 서비스를 사용하기 위해 회원 가입이 필요합니다.

## 작업내용
- 기존 회원 가입 페이지의 email, password, first name, last name 입력 폼에서 ID, 이름, 이메일, 패스워드, 패스워드 재입력 입력 폼으로 변경합니다.
- 입력 폼 모두 필수값으로 받고 패스워드값과 패스워드 재입력값이 같은지 유효성 검증을 합니다.
- 회원 가입 실패 시 alert 으로 실패 문구를 보여줍니다.
- 회원 가입 성공 시 로그인 페이지로 이동합니다.

## 테스트방법
- yarn dev 명령어로 로컬 서버를 실행합니다.
- 회원 가입 페이지에서 유효성 검증을 확인 합니다.
- 회원 가입 성공 시 로그인 페이지로 이동되는지 확인 합니다.
