### PR TITLE
아이디를 찾을 수 있도록 폼을 생성하고 아이디 찾기 API를 연결합니다.

### DIFF
--- a/components/FindId.tsx
+++ b/components/FindId.tsx
@@ -1,0 +1,124 @@
+import Container from "@mui/material/Container";
+import Box from "@mui/material/Box";
+import Avatar from "@mui/material/Avatar";
+import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
+import Typography from "@mui/material/Typography";
+import TextField from "@mui/material/TextField";
+import Button from "@mui/material/Button";
+import Grid from "@mui/material/Grid";
+import NextLink from "next/link";
+import {Link as MUILink} from '@mui/material';
+
+export default function FindIdForm() {
+    // 아이디 찾기를 처리하는 함수
+    const handleFindID = async (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        const data = new FormData(event.currentTarget);
+        const user_name = data.get('user_name') ?? "";
+        const email = data.get('email') ?? "";
+
+        if (!user_name) {
+            alert('아이디를 입력해주세요.');
+            return false;
+        }
+        if (!email) {
+            alert('이메일을 입력해주세요.');
+            return false;
+        }
+
+        const emailRegex = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@(([^<>()[\]\\.,;:\s@"]+\.)+[^<>()[\]\\.,;:\s@"]{2,})$/i;
+        if (!email && !emailRegex.test(email)) {
+            alert('올바른 이메일 주소를 입력해주세요.');
+            return;
+        }
+
+        try {
+            const url = `${process.env.NEXT_PUBLIC_API_URL}/api/user/findId`;
+            const response = await fetch(url, {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({user_name, email}),
+            });
+
+            if (response.ok) {
+                const result = await response.json();
+                if (result.result === 'sucess') {
+                    alert(`아이디: ${result.user_id}`);
+                } else {
+                    console.log(result);
+                }
+            } else {
+                const result = await response.json();
+                alert('아이디 찾기 실패: ' + result.error[0]);
+            }
+        } catch (error) {
+            alert('아이디 찾기 중 에러 발생:' + error);
+        }
+    };
+
+    return (
+        <>
+            <Container component="main" maxWidth="xs">
+                <Box
+                    sx={{
+                        marginTop: 8,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                    }}
+                >
+                    <Avatar sx={{ m: 1, bgcolor: 'secondary.main' }}>
+                        <LockOutlinedIcon />
+                    </Avatar>
+                    <Typography component="h1" variant="h5">
+                        아이디 찾기
+                    </Typography>
+                    <Box component="form" onSubmit={handleFindID} noValidate sx={{ mt: 1 }}>
+                        <TextField
+                            margin="normal"
+                            required
+                            fullWidth
+                            id="email"
+                            label="Email"
+                            name="email"
+                            autoComplete="email"
+                        />
+                        <TextField
+                            margin="normal"
+                            required
+                            fullWidth
+                            id="user_name"
+                            label="이름"
+                            name="user_name"
+                            autoComplete="이름"
+                        />
+                        <Button
+                            type="submit"
+                            fullWidth
+                            variant="contained"
+                            sx={{ mt: 3, mb: 2 }}
+                        >
+                            아이디 찾기
+                        </Button>
+                        <Grid container>
+                            <Grid item xs>
+                                <NextLink href="/signin" passHref>
+                                    <MUILink variant="body2" component={"button"} sx={{ color: 'black', textDecoration: 'none' }}>
+                                        로그인하러 이동
+                                    </MUILink>
+                                </NextLink>
+                            </Grid>
+                            <Grid item>
+                                <NextLink href="/signup" passHref>
+                                    <MUILink variant="body2" component={"button"} sx={{ color: 'black', textDecoration: 'none' }}>
+                                        회원가입
+                                    </MUILink>
+                                </NextLink>
+                            </Grid>
+                        </Grid>
+                    </Box>
+                </Box>
+            </Container>
+        </>
+    );
+}

--- a/components/FindId.tsx
+++ b/components/FindId.tsx
@@ -45,7 +45,7 @@ export default function FindIdForm() {
                 if (result.result === 'sucess') {
                     alert(`아이디: ${result.user_id}`);
                 } else {
-                    console.log(result);
+                    alert(result.message);
                 }
             } else {
                 const result = await response.json();

--- a/components/SignIn.tsx
+++ b/components/SignIn.tsx
@@ -91,18 +91,26 @@ export default function SignIn() {
 						>
 							Sign In
 						</Button>
-						<Grid container>
-							<Grid item xs>
-								<NextLink href="/" passHref>
-									<MUILink variant="body2" component={"button"}>
-										Forgot password?
-									</MUILink>
-								</NextLink>
+						<Grid container justifyContent="space-between" alignItems="center">
+							<Grid item>
+								<Typography variant="body2">
+									<NextLink href="/findId" passHref>
+										<MUILink sx={{ color: 'black', textDecoration: 'none' }}>
+											아이디 찾기
+										</MUILink>
+									</NextLink>
+									{' / '}
+									<NextLink href="/find-password" passHref>
+										<MUILink sx={{ color: 'black', textDecoration: 'none' }}>
+											패스워드 찾기
+										</MUILink>
+									</NextLink>
+								</Typography>
 							</Grid>
 							<Grid item>
 								<NextLink href="/signup" passHref>
-									<MUILink variant="body2" component={"button"}>
-										{"Don't have an account? Sign Up"}
+									<MUILink sx={{ color: 'black', textDecoration: 'none' }} variant="body2">
+										회원가입
 									</MUILink>
 								</NextLink>
 							</Grid>

--- a/pages/findId.tsx
+++ b/pages/findId.tsx
@@ -1,0 +1,9 @@
+import FindId from '../components/FindId';
+
+export default function findId() {
+    return (
+        <div>
+            <FindId />
+        </div>
+    )
+}


### PR DESCRIPTION
## 배경
- 아이디를 잊어버렸을 때 아이디를 찾을 수 있어야 합니다.

## 작업내용
- 로그인 페이지에 아이디 찾기 버튼을 추가합니다.
- 이름, 이메일을 입력 받을 수 있는 아이디 찾기 폼을 생성합니다.
- 아이디 찾기 API와 연결합니다.
- 아이디를 찾으면 alert 으로 찾은 아이디를 보여줍니다.
- 에러 발생 시 alert 으로 에러 내용을 보여줍니다.

## 테스트방법
- yarn dev 명령어로 로컬 서버를 실행합니다.
- 아이디 찾기 페이지로 이동합니다.(/findId)
- 이메일, 이름을 입력하고 alert 으로 오류가 발생하는지, 본인의 아이디가 나오는지 확인합니다.

## 스크린샷
![image.jpg1](https://github.com/Genithlabs/Memorial/assets/15684441/cdddc4de-34d2-4a3a-bce0-aecc76782699) |![image.jpg2](https://github.com/Genithlabs/Memorial/assets/15684441/3e4cbe76-48e9-444e-bf19-4e25769a7ce3)
--- | --- | 
