### PR TITLE
비밀번호 변경 API를 사용하여 비밀번호 찾기를 할 수 있습니다.

### DIFF
--- a/components/FindPassword.tsx
+++ b/components/FindPassword.tsx
@@ -1,0 +1,134 @@
+import {Property} from "csstype";
+import Container from "@mui/material/Container";
+import Avatar from "@mui/material/Avatar";
+import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
+import Typography from "@mui/material/Typography";
+import Box from "@mui/material/Box";
+import TextField from "@mui/material/TextField";
+import Button from "@mui/material/Button";
+import Grid from "@mui/material/Grid";
+import NextLink from "next/link";
+import {Link as MUILink} from "@mui/material";
+
+
+export default function FindPasswordForm() {
+    const handleFindPassword = async (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        const data = new FormData(event.currentTarget);
+        const user_name = data.get('user_name') ?? "";
+        const email = data.get('email') ?? "";
+        const user_id = data.get('user_id') ?? "";
+
+        if (!user_name) {
+            alert('이름을 입력해주세요.');
+            return false;
+        }
+        if (!email) {
+            alert('이메일을 입력해주세요.');
+            return false;
+        }
+        if (!user_id) {
+            alert('아이디를 입력해주세요.');
+            return false;
+        }
+
+        const emailRegex = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@(([^<>()[\]\\.,;:\s@"]+\.)+[^<>()[\]\\.,;:\s@"]{2,})$/i;
+        if (!email && !emailRegex.test(email)) {
+            alert('올바른 이메일 주소를 입력해주세요.');
+            return;
+        }
+
+        try {
+            const url = `${process.env.NEXT_PUBLIC_API_URL}/api/user/forgot_password`;
+            const response = await fetch(url, {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({user_name, email, user_id}),
+            });
+
+            if (response.ok) {
+                const result = await response.json();
+                alert(result.message);
+            } else {
+                const result = await response.json();
+                alert('비밀번호 찾기 실패: ' + result.error[0]);
+            }
+        } catch (error) {
+            alert('비밀번호 찾기 중 에러 발생:' + error);
+        }
+    };
+    return (
+        <>
+            <Container component="main" maxWidth="xs">
+                <Box
+                    sx={{
+                        marginTop: 8,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                    }}
+                >
+                    <Avatar sx={{ m: 1, bgcolor: 'secondary.main' }}>
+                        <LockOutlinedIcon />
+                    </Avatar>
+                    <Typography component="h1" variant="h5">
+                        비밀번호 찾기
+                    </Typography>
+                    <Box component="form" onSubmit={handleFindPassword} noValidate sx={{ mt: 1 }}>
+                        <TextField
+                            margin="normal"
+                            required
+                            fullWidth
+                            id="email"
+                            label="Email"
+                            name="email"
+                            autoComplete="email"
+                        />
+                        <TextField
+                            margin="normal"
+                            required
+                            fullWidth
+                            id="user_name"
+                            label="이름"
+                            name="user_name"
+                            autoComplete="이름"
+                        />
+                        <TextField
+                            margin="normal"
+                            required
+                            fullWidth
+                            id="user_id"
+                            label="ID"
+                            name="user_id"
+                            autoComplete="ID"
+                        />
+                        <Button
+                            type="submit"
+                            fullWidth
+                            variant="contained"
+                            sx={{ mt: 3, mb: 2 }}
+                        >
+                            비밀번호 찾기
+                        </Button>
+                        <Grid container>
+                            <Grid item xs>
+                                <NextLink href="/signin" passHref>
+                                    <MUILink variant="body2" component={"button"}>
+                                        로그인하러 이동
+                                    </MUILink>
+                                </NextLink>
+                            </Grid>
+                            <Grid item>
+                                <NextLink href="/signup" passHref>
+                                    <MUILink variant="body2" component={"button"}>
+                                        회원가입
+                                    </MUILink>
+                                </NextLink>
+                            </Grid>
+                        </Grid>
+                    </Box>
+                </Box>
+            </Container>
+        </>
+    );
+}

--- a/components/ResetPassword.tsx
+++ b/components/ResetPassword.tsx
@@ -118,7 +118,7 @@ export default function ResetPasswordForm() {
                             variant="contained"
                             sx={{ mt: 3, mb: 2 }}
                         >
-                            아이디 찾기
+                            비밀번호 변경
                         </Button>
                     </Box>
                 </Box>

--- a/components/ResetPassword.tsx
+++ b/components/ResetPassword.tsx
@@ -1,0 +1,128 @@
+import Container from "@mui/material/Container";
+import Avatar from "@mui/material/Avatar";
+import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
+import Typography from "@mui/material/Typography";
+import Box from "@mui/material/Box";
+import TextField from "@mui/material/TextField";
+import Button from "@mui/material/Button";
+import {useRouter} from "next/router";
+
+
+export default function ResetPasswordForm() {
+    const router = useRouter();
+    const { token } = router.query;
+
+    const handleResetPassword = async (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        const data = new FormData(event.currentTarget);
+        const password = data.get('password') ?? "";
+        const password_confirmation = data.get('password_confirmation') ?? "";
+        const email = data.get('email') ?? "";
+
+        if (!token) {
+            alert('토큰이 유효하지 않습니다.');
+            return;
+        }
+
+        if (!email) {
+            alert('이메일을 입력해주세요.');
+            return false;
+        }
+        if (!password) {
+            alert('새로운 비밀번호를 입력해주세요.');
+            return false;
+        }
+        if (!password_confirmation) {
+            alert('새로운 비밀번호 확인을 입력해주세요.');
+            return false;
+        }
+        if (password != password_confirmation) {
+            alert('비밀번호가 일치하지 않습니다.');
+            return false;
+        }
+
+        const emailRegex = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@(([^<>()[\]\\.,;:\s@"]+\.)+[^<>()[\]\\.,;:\s@"]{2,})$/i;
+        if (!email && !emailRegex.test(email)) {
+            alert('올바른 이메일 주소를 입력해주세요.');
+            return;
+        }
+
+        try {
+            const url = `${process.env.NEXT_PUBLIC_API_URL}/api/user/reset_password`;
+            const response = await fetch(url, {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({email, password, password_confirmation, token}),
+            });
+
+            if (response.ok) {
+                const result = await response.json();
+                alert(result.message);
+                router.push('/signin');
+            } else {
+                const result = await response.json();
+                alert('비밀번호 변경 실패: ' + result.error[0]);
+            }
+        } catch (error) {
+            alert('비밀번호 변경 에러 발생:' + error);
+        }
+    };
+    return (
+        <>
+            <Container component="main" maxWidth="xs">
+                <Box
+                    sx={{
+                        marginTop: 8,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                    }}
+                >
+                    <Avatar sx={{ m: 1, bgcolor: 'secondary.main' }}>
+                        <LockOutlinedIcon />
+                    </Avatar>
+                    <Typography component="h1" variant="h5">
+                        비밀번호 변경
+                    </Typography>
+                    <Box component="form" onSubmit={handleResetPassword} noValidate sx={{ mt: 1 }}>
+                        <TextField
+                            margin="normal"
+                            required
+                            fullWidth
+                            id="email"
+                            label="Email"
+                            name="email"
+                            autoComplete="email"
+                        />
+                        <TextField
+                            margin="normal"
+                            required
+                            fullWidth
+                            id="password"
+                            label="새로운 비밀번호"
+                            name="password"
+                            type="password"
+                        />
+                        <TextField
+                            margin="normal"
+                            required
+                            fullWidth
+                            id="password_confirmation"
+                            label="새로운 비밀번호 확인"
+                            name="password_confirmation"
+                            type="password"
+                        />
+                        <Button
+                            type="submit"
+                            fullWidth
+                            variant="contained"
+                            sx={{ mt: 3, mb: 2 }}
+                        >
+                            아이디 찾기
+                        </Button>
+                    </Box>
+                </Box>
+            </Container>
+        </>
+    )
+}

--- a/pages/find-password.tsx
+++ b/pages/find-password.tsx
@@ -1,0 +1,9 @@
+import FindPassword from '../components/FindPassword';
+
+export default function findId() {
+    return (
+        <div>
+            <FindPassword />
+        </div>
+    )
+}

--- a/pages/reset-password/[token].tsx
+++ b/pages/reset-password/[token].tsx
@@ -1,0 +1,10 @@
+import ResetPassword from "@/components/ResetPassword";
+
+
+export default function resetPassword() {
+    return (
+        <div>
+            <ResetPassword />
+        </div>
+    )
+}


### PR DESCRIPTION
## 배경
- 비밀번호가 기억나지 않을 때 비밀번호를 찾을 수 있어야 합니다.

## 작업내용
- 비밀번호 찾기 페이지를 생성합니다.
- **비밀번호 찾기 이메일**을 받기 위해 비밀번호 찾기 API을 연동합니다.
- 비밀번호 연동 페이지를 생성합니다.
- 비밀번호 변경 API를 연동합니다.
- 비밀번호 변경 성공 시 로그인 페이지로 리다이렉트 합니다.

## 테스트방법
- yarn dev 명령어로 로컬 서버를 실행합니다.
- 비밀번호 찾기 페이지로 이동합니다.(http://localhost:3000/forgot-password)
- 값을 모두 입력한 후에 **비밀번호 찾기** 버튼을 누릅니다.
- 입력한 이메일 주소로 이메일이 왔는지 확인 후 비밀번호 변경 페이지 (http://localhost:3000/reset-password/{token}) 로 이동합니다.
- 입력값들을 모두 입력한 후에 **비밀번호 변경** 버튼을 눌러 정상적으로 비밀번호가 변경되는지 확인합니다.

## 스크린샷
![image.jpg1](https://github.com/Genithlabs/Memorial/assets/15684441/5a84a0bf-6724-431b-8d40-74665a7aadd9) |![image.jpg2](https://github.com/Genithlabs/Memorial/assets/15684441/427e475d-1752-4575-a32e-b07a1f891465)
--- | --- | 


