### PR TITLE
생애 소개 입력 시 이미지를 업로드할 수 있습니다

### DIFF
--- a/components/form/TextEditor.tsx
+++ b/components/form/TextEditor.tsx
@@ -1,17 +1,19 @@
 import { useEffect, useRef } from 'react';
 import Quill from 'quill';
-import 'quill/dist/quill.snow.css'; // import styles
+import 'quill/dist/quill.snow.css';
+import {useSession} from "next-auth/react"; // import styles
 
 type ContentProps = {
 	content: string,
 	setContent: (content: any) => void
 }
 
-function TextEditor({content, setContent}: ContentProps) {
-	const quillRef = useRef(null);
+function TextEditor({ content, setContent }: ContentProps) {
+	const {data: session} = useSession();
+	const quillRef = useRef<HTMLDivElement | null>(null);
 
 	useEffect(() => {
-		if (typeof window !== 'undefined' && quillRef.current) {
+		if (typeof window !== 'undefined' && quillRef.current && session) {
 			const quill = new Quill(quillRef.current, {
 				theme: 'snow',
 				modules: {
@@ -26,11 +28,45 @@ function TextEditor({content, setContent}: ContentProps) {
 					],
 				},
 			});
+
+			const imageHandler = () => {
+				const input = document.createElement('input');
+				input.setAttribute('type', 'file');
+				input.setAttribute('accept', 'image/*');
+				document.body.appendChild(input);
+				input.click();
+
+				input.onchange = async () => {
+					if (input.files && input.files.length > 0) {
+						const file = input.files[0];
+						const formData = new FormData();
+						formData.append('career_contents_file', file);
+
+						const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/memorial/upload`, {
+							method: 'POST',
+							headers: {
+								'Authorization': `Bearer ${session.accessToken}`
+							},
+							body: formData,
+						});
+
+						if (response.ok) {
+							const data = await response.json();
+							const range = quill.getSelection(true);
+							const url = data.url; // 서버에서 반환된 이미지 URL
+							quill.insertEmbed(range.index, 'image', url);
+						}
+					}
+				};
+			};
+
+			quill.getModule('toolbar').addHandler('image', imageHandler);
+
 			quill.on('text-change', () => {
-				setContent(quill.root.innerHTML)
+				setContent(quill.root.innerHTML);
 			});
 		}
-	}, []);
+	}, [setContent]);
 
 	return (
 		<div id="container">


### PR DESCRIPTION
## 배경
- 생애 정보 입력 시 이미지를 첨부할 수 있어야 합니다.

## 작업내용
- Quill 텍스트 에디터에서 이미지 첨부 시 이미지 업로드 API를 호출합니다.
- 업로드된 이미지 URL 을 텍스트 에디터에 넣습니다.

## 테스트방법
- yarn dev 명령어로 로컬 서버를 실행합니다.
- 로그인 후 '새로 기념관 건립' 혹은 '내가 건립한 기념관 수정' 버튼을 눌러 기념관 입력 form 으로 이동합니다.
- 생애 정보 입력 시 이미지를 업로드하여 정상적으로 에디터 안에 이미지가 노출되는 지 확인합니다.

## 스크린샷
<img width="1420" alt="스크린샷 2024-04-15 오후 1 33 58" src="https://github.com/Genithlabs/Memorial/assets/15684441/3e721451-e1aa-4f7f-8408-348caa8399d8">