### PR TITLE
기념관 상세 페이지를 조회합니다

### DIFF
--- a/components/Detail.tsx
+++ b/components/Detail.tsx
@@ -10,7 +10,7 @@ const getYearFromDate = (dateStr: string): string => {
 	return date.getFullYear().toString();
 }
 
-export default function Detail({ visitorMessages, memories, detail }: ALLProps) {
+export default function Detail({ visitorMessages, memories, detail, memorialId }: ALLProps) {
 	// Extract only the year from birth_start and birth_end
 	const birthStartYear = getYearFromDate(detail.birth_start);
 	const birthEndYear = getYearFromDate(detail.birth_end);
@@ -91,7 +91,7 @@ export default function Detail({ visitorMessages, memories, detail }: ALLProps) 
 					</Typography>
 				</Container>
 				<Container sx={{ mt: {xs:"5rem", sm: "7.5rem", md: "10rem"} }}>
-					<TabsCustomized visitorMessages={visitorMessages} memories={memories} detail={detail}/>
+					<TabsCustomized visitorMessages={visitorMessages} memories={memories} detail={detail} memorialId={memorialId}/>
 				</Container>
 			</main>
 		</>

--- a/components/Detail.tsx
+++ b/components/Detail.tsx
@@ -75,7 +75,7 @@ export default function Detail({ visitorMessages, memories, detail, memorialId }
 							fontWeight: 'bold',
 						}}
 					>
-						이름
+						{detail.user_name}
 					</Typography>
 					<Typography
 						sx={{

--- a/components/Detail.tsx
+++ b/components/Detail.tsx
@@ -4,12 +4,21 @@ import Container from "@mui/material/Container";
 import TabsCustomized from './detail/TabsCustomized';
 import {ALLProps} from './detail/interfaces';
 
+
+const getYearFromDate = (dateStr: string): string => {
+	const date = new Date(dateStr);
+	return date.getFullYear().toString();
+}
+
 export default function Detail({ visitorMessages, memories, detail }: ALLProps) {
+	// Extract only the year from birth_start and birth_end
+	const birthStartYear = getYearFromDate(detail.birth_start);
+	const birthEndYear = getYearFromDate(detail.birth_end);
 	return (
 		<>
 			<main>
 				<div style={{ position: 'relative', width: '100%', height: '20rem'}}>
-					<Image src={detail?.backgroundImage} alt="background image" fill sizes="(max-width: 768px) 100vw,(max-width: 1200px) 50vw,33vw" style={{ objectFit: 'cover' }}/>
+					<Image src="/cloud2.png" alt="background image" fill sizes="(max-width: 768px) 100vw,(max-width: 1200px) 50vw,33vw" style={{ objectFit: 'cover' }}/>
 				</div>
 				<Container
 					sx={{
@@ -34,7 +43,15 @@ export default function Detail({ visitorMessages, memories, detail }: ALLProps) 
 						overflow: "auto",
 						boxShadow: '0px 4px 10px rgba(0, 0, 0, 0.5)',
 				}}>
-					<Image src={detail?.profileImage} alt="profile image" fill sizes="(max-width: 768px) 100vw,(max-width: 1200px) 50vw,33vw" />
+					{detail?.attachment_profile_image && (
+						<Image
+							src={`${process.env.NEXT_PUBLIC_IMAGE}${detail.attachment_profile_image.file_path}${detail.attachment_profile_image.file_name}`}
+							alt="profile image"
+							fill
+							sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+							style={{ objectFit: 'cover' }}
+						/>
+					)}
 				</Container>
 				<Container
 					sx={{
@@ -58,7 +75,7 @@ export default function Detail({ visitorMessages, memories, detail }: ALLProps) 
 							fontWeight: 'bold',
 						}}
 					>
-						{detail?.name}
+						이름
 					</Typography>
 					<Typography
 						sx={{
@@ -70,7 +87,7 @@ export default function Detail({ visitorMessages, memories, detail }: ALLProps) 
 							fontWeight: '400',
 						}}
 					>
-						{detail?.birth}
+						{birthStartYear} - {birthEndYear}
 					</Typography>
 				</Container>
 				<Container sx={{ mt: {xs:"5rem", sm: "7.5rem", md: "10rem"} }}>

--- a/components/detail/Life.tsx
+++ b/components/detail/Life.tsx
@@ -7,7 +7,7 @@ import {useState} from "react";
 import Grow from "@mui/material/Grow";
 import {LifeProps} from "./interfaces";
 
-export default function Life({visitorMessages, detail}:LifeProps) {
+export default function Life({visitorMessages, detail, memorialId}:LifeProps) {
 
 	const [showTextArea, setShowTextArea] = useState(false);
 

--- a/components/detail/Life.tsx
+++ b/components/detail/Life.tsx
@@ -23,7 +23,7 @@ export default function Life({visitorMessages, detail}:LifeProps) {
 			}}
 			  className={"diff-card-section"}
 			>
-				{detail && <div dangerouslySetInnerHTML={{ __html: detail.contents }} />}
+				{detail && <div dangerouslySetInnerHTML={{ __html: detail.career_contents }} />}
 			</Container>
 			<Box>
 				<Typography sx={{
@@ -61,18 +61,23 @@ export default function Life({visitorMessages, detail}:LifeProps) {
 				)}
 			</Box>
 			<Box sx={{ mt: "1rem" }}>
-				{visitorMessages?.map(({date, message, name}, index) => (
-					<Box key={index} sx={{ p: '1rem', mt: index !== 0 ? '2rem' : '0' }} className={"diff-card-section"}>
-						<div style={{display:"flex"}}>
-							<Typography>{name}</Typography>
-							<Typography sx={{ p: "0 .5rem"}}>•</Typography>
-							<Typography>{date}</Typography>
-						</div>
-						<div>
-							<div dangerouslySetInnerHTML={{ __html: message }} />
-						</div>
-					</Box>
-				))}
+				{visitorMessages?.map(({created_at, message, user_name}, index) => {
+					const date = new Date(created_at);
+					const formattedDate = `${date.getMonth() + 1}월 ${date.getDate()}일`;
+
+					return (
+						<Box key={index} sx={{ p: '1rem', mt: index !== 0 ? '2rem' : '0' }} className={"diff-card-section"}>
+							<div style={{display:"flex"}}>
+								<Typography>{user_name}</Typography>
+								<Typography sx={{ p: "0 .5rem"}}>•</Typography>
+								<Typography>{formattedDate}</Typography>
+							</div>
+							<div>
+								<div dangerouslySetInnerHTML={{ __html: message }} />
+							</div>
+						</Box>
+					);
+				})}
 			</Box>
 		</>
 	)

--- a/components/detail/Memory.tsx
+++ b/components/detail/Memory.tsx
@@ -55,18 +55,22 @@ export default function Memory({ memories }: { memories: Memory[] }) {
 			   }
 			</Box>
 			<Box sx={{ mt: "1rem" }}>
-				{memories.map(({date, message, name}, index) => (
-					<Box key={index} sx={{ p: '1rem', mt: index !== 0 ? '2rem' : '0' }} className={"diff-card-section"}>
-						<div style={{display:"flex"}}>
-							<Typography>{name}</Typography>
-							<Typography sx={{ p: "0 .5rem"}}>•</Typography>
-							<Typography>{date}</Typography>
-						</div>
-						<div>
-							<div dangerouslySetInnerHTML={{ __html: message }} />
-						</div>
-					</Box>
-				))}
+				{memories.map(({created_at, message}, index) => {
+					const date = new Date(created_at);
+					const formattedDate = `${date.getMonth() + 1}월 ${date.getDate()}일`;
+
+					return (
+						<Box key={index} sx={{ p: '1rem', mt: index !== 0 ? '2rem' : '0' }} className={"diff-card-section"}>
+							<div style={{display:"flex"}}>
+								<Typography sx={{ p: "0 .5rem"}}>•</Typography>
+								<Typography>{formattedDate}</Typography>
+							</div>
+							<div>
+								<div dangerouslySetInnerHTML={{ __html: message }} />
+							</div>
+						</Box>
+					);
+				})}
 			</Box>
 		</>
 	)

--- a/components/detail/Memory.tsx
+++ b/components/detail/Memory.tsx
@@ -4,9 +4,9 @@ import Button from "@mui/material/Button";
 import {useState} from "react";
 import MemoryForm from "@/components/detail/MemoryForm";
 import Grow from "@mui/material/Grow";
-import {Memory} from "./interfaces";
+import {MemoryProps} from "./interfaces";
 
-export default function Memory({ memories }: { memories: Memory[] }) {
+export default function Memory({ memories, memorialId }: MemoryProps) {
 
 	const [showFrom, setShowFormArea] = useState(false);
 	const [initialLoad, setInitialLoad] = useState(true);  // 처음 로드 여부를 확인하는 상태

--- a/components/detail/Memory.tsx
+++ b/components/detail/Memory.tsx
@@ -62,6 +62,7 @@ export default function Memory({ memories }: { memories: Memory[] }) {
 					return (
 						<Box key={index} sx={{ p: '1rem', mt: index !== 0 ? '2rem' : '0' }} className={"diff-card-section"}>
 							<div style={{display:"flex"}}>
+								<Typography>이름</Typography>
 								<Typography sx={{ p: "0 .5rem"}}>•</Typography>
 								<Typography>{formattedDate}</Typography>
 							</div>

--- a/components/detail/Memory.tsx
+++ b/components/detail/Memory.tsx
@@ -55,14 +55,14 @@ export default function Memory({ memories, memorialId }: MemoryProps) {
 			   }
 			</Box>
 			<Box sx={{ mt: "1rem" }}>
-				{memories.map(({created_at, message}, index) => {
+				{memories.map(({created_at, message, user_name}, index) => {
 					const date = new Date(created_at);
 					const formattedDate = `${date.getMonth() + 1}월 ${date.getDate()}일`;
 
 					return (
 						<Box key={index} sx={{ p: '1rem', mt: index !== 0 ? '2rem' : '0' }} className={"diff-card-section"}>
 							<div style={{display:"flex"}}>
-								<Typography>이름</Typography>
+								<Typography>{user_name || "이름"}</Typography>
 								<Typography sx={{ p: "0 .5rem"}}>•</Typography>
 								<Typography>{formattedDate}</Typography>
 							</div>

--- a/components/detail/TabsCustomized.tsx
+++ b/components/detail/TabsCustomized.tsx
@@ -9,15 +9,15 @@ import Memory from "./Memory";
 import { ALLProps } from './interfaces';
 
 
-export default function TabsCustomized({ visitorMessages, memories, detail }: ALLProps) {
+export default function TabsCustomized({ visitorMessages, memories, detail, memorialId }: ALLProps) {
 	return (
 		<Tabs defaultValue={1}>
 			<StyledTabsList>
 				<StyledTab value={1}>생애<br/>Life</StyledTab>
 				<StyledTab value={2}>추억과 메모리<br/>Memory And Message</StyledTab>
 			</StyledTabsList>
-			<StyledTabPanel value={1}><Life visitorMessages={visitorMessages} detail={detail}/></StyledTabPanel>
-			<StyledTabPanel value={2}><Memory memories={memories} /></StyledTabPanel>
+			<StyledTabPanel value={1}><Life visitorMessages={visitorMessages} detail={detail} memorialId={memorialId} /></StyledTabPanel>
+			<StyledTabPanel value={2}><Memory memories={memories} memorialId={memorialId} /></StyledTabPanel>
 		</Tabs>
 	);
 }

--- a/components/detail/interfaces.ts
+++ b/components/detail/interfaces.ts
@@ -12,6 +12,7 @@ export interface VisitorMessage {
 export interface Memory {
 	id: number
 	user_id: number
+	user_name: string|null
 	memorial_id: number
 	title: string
 	message: string

--- a/components/detail/interfaces.ts
+++ b/components/detail/interfaces.ts
@@ -22,47 +22,54 @@ export interface Memory {
 }
 
 export interface AttachmentProfileImage {
-	id: number;
-	file_path: string;
-	file_name: string;
-	is_delete: number;
-	deleted_at: string | null;
-	created_at: string;
-	updated_at: string;
+	id: number
+	file_path: string
+	file_name: string
+	is_delete: number
+	deleted_at: string | null
+	created_at: string
+	updated_at: string
 }
 
 export interface AttachmentBgm {
-	id: number;
-	file_path: string;
-	file_name: string;
-	is_delete: number;
-	deleted_at: string | null;
-	created_at: string;
-	updated_at: string;
+	id: number
+	file_path: string
+	file_name: string
+	is_delete: number
+	deleted_at: string | null
+	created_at: string
+	updated_at: string
 }
 
 
 export interface Detail {
-	id: number;
-	birth_start: string;
-	birth_end: string;
-	career_contents: string;
-	is_open: number;
-	profile_attachment_id: number;
-	bgm_attachment_id: number;
-	created_at: string;
-	updated_at: string;
-	attachment_profile_image: AttachmentProfileImage;
-	attachment_bgm: AttachmentBgm;
+	id: number
+	birth_start: string
+	birth_end: string
+	career_contents: string
+	is_open: number
+	profile_attachment_id: number
+	bgm_attachment_id: number
+	created_at: string
+	updated_at: string
+	attachment_profile_image: AttachmentProfileImage
+	attachment_bgm: AttachmentBgm
 }
 
 export interface ALLProps {
-	visitorMessages: VisitorMessage[];
-	memories: Memory[];
-	detail: Detail;
+	visitorMessages: VisitorMessage[]
+	memories: Memory[]
+	detail: Detail
+	memorialId: number
 }
 
 export interface LifeProps {
-	visitorMessages: VisitorMessage[];
-	detail: Detail;
+	visitorMessages: VisitorMessage[]
+	detail: Detail
+	memorialId: number
+}
+
+export interface MemoryProps {
+	memories: Memory[]
+	memorialId: number
 }

--- a/components/detail/interfaces.ts
+++ b/components/detail/interfaces.ts
@@ -1,21 +1,59 @@
 export interface VisitorMessage {
-	name: string;
-	date: string;
-	message: string;
+	id: number
+	user_id: number
+	user_name: string
+	memorial_id: number
+	message: string
+	is_visible: number
+	created_at: string
+	updated_at: string
 }
 
 export interface Memory {
-	name: number;
-	date: string;
-	message: string;
+	id: number
+	user_id: number
+	memorial_id: number
+	title: string
+	message: string
+	attachment_id: number
+	is_visible: number
+	created_at: string
+	updated_at: string
 }
 
+export interface AttachmentProfileImage {
+	id: number;
+	file_path: string;
+	file_name: string;
+	is_delete: number;
+	deleted_at: string | null;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface AttachmentBgm {
+	id: number;
+	file_path: string;
+	file_name: string;
+	is_delete: number;
+	deleted_at: string | null;
+	created_at: string;
+	updated_at: string;
+}
+
+
 export interface Detail {
-	backgroundImage: string,
-	profileImage: string,
-	name: string,
-	birth: string,
-	contents: string,
+	id: number;
+	birth_start: string;
+	birth_end: string;
+	career_contents: string;
+	is_open: number;
+	profile_attachment_id: number;
+	bgm_attachment_id: number;
+	created_at: string;
+	updated_at: string;
+	attachment_profile_image: AttachmentProfileImage;
+	attachment_bgm: AttachmentBgm;
 }
 
 export interface ALLProps {

--- a/components/detail/interfaces.ts
+++ b/components/detail/interfaces.ts
@@ -45,6 +45,7 @@ export interface AttachmentBgm {
 
 export interface Detail {
 	id: number
+	user_name: string
 	birth_start: string
 	birth_end: string
 	career_contents: string

--- a/pages/detail/[memorialId].tsx
+++ b/pages/detail/[memorialId].tsx
@@ -1,6 +1,25 @@
 import Detail from '../../components/Detail';
 import { GetServerSideProps } from "next";
-import {ALLProps, AttachmentBgm, AttachmentProfileImage} from "@/components/detail/interfaces";
+import { ALLProps } from "@/components/detail/interfaces";
+
+async function fetchData(url: string, errorContext: string) {
+	const response = await fetch(url);
+
+	if (!response.ok) {
+		const errorResult = await response.json();
+		console.error(`${errorContext} - API Response Error:`, errorResult);
+		throw new Error('Failed to fetch data.');
+	}
+
+	const result = await response.json();
+
+	if (result.result !== 'success') {
+		console.error(`${errorContext} - API Error Message:`, result.message);
+		throw new Error('API response was not successful.');
+	}
+
+	return result.data;
+}
 
 export default function DetailPage(props: ALLProps) {
 	return <Detail {...props} />;
@@ -12,61 +31,49 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 			throw new Error("Params are missing");
 		}
 
-		// memorialId를 number로 변환
 		const memorialId = Number(context.params.memorialId);
 
 		if (isNaN(memorialId)) {
 			throw new Error("Invalid memorialId");
 		}
 
-		// API 호출
-		const url = `${process.env.NEXT_PUBLIC_API_URL}/api/memorial/${memorialId}/detail`;
-		const response = await fetch(url);
-
-		// API 응답 상태 확인
-		if (response.ok) {
-			const result = await response.json();
-
-			// API 결과가 성공인 경우에만 데이터 설정
-			if (result.result === 'success') {
-				const data = result.data;
-
-				const visitorMessages = data.visit_comments;
-				const memories = data.story;
-				const detail = {
-					id: data.id,
-					birth_start: data.birth_start,
-					birth_end: data.birth_end,
-					career_contents: data.career_contents,
-					is_open: data.is_open,
-					profile_attachment_id: data.profile_attachment_id,
-					bgm_attachment_id: data.bgm_attachment_id,
-					created_at: data.created_at,
-					updated_at: data.updated_at,
-					attachment_profile_image: data.attachment_profile_image,
-					attachment_bgm: data.attachment_bgm,
-				};
-
-				return {
-					props: {
-						visitorMessages,
-						memories,
-						detail,
-						memorialId,
-					}
-				};
-			} else {
-				console.error('API 오류 메시지:', result.message);
-				return { notFound: true };
-			}
-		} else {
-			const errorResult = await response.json();
-			console.error('API 응답 오류:', errorResult);
-			return { notFound: true };
+		const baseUrl = process.env.NEXT_PUBLIC_API_URL;
+		if (!baseUrl) {
+			throw new Error("API URL is missing");
 		}
+
+		const memorialUrl = `${baseUrl}/api/memorial/${memorialId}/detail`;
+		const commentUrl = `${baseUrl}/api/memorial/${memorialId}/comments`;
+		const storyUrl = `${baseUrl}/api/memorial/${memorialId}/stories`;
+
+		const detail = await fetchData(memorialUrl, 'Memorial Detail');
+		const visitorMessages = await fetchData(commentUrl, 'Visitor Messages');
+		const memories = await fetchData(storyUrl, 'Stories');
+
+		const formattedDetail = {
+			id: detail.id,
+			birth_start: detail.birth_start,
+			birth_end: detail.birth_end,
+			career_contents: detail.career_contents,
+			is_open: detail.is_open,
+			profile_attachment_id: detail.profile_attachment_id,
+			bgm_attachment_id: detail.bgm_attachment_id,
+			created_at: detail.created_at,
+			updated_at: detail.updated_at,
+			attachment_profile_image: detail.attachment_profile_image,
+			attachment_bgm: detail.attachment_bgm,
+		};
+
+		return {
+			props: {
+				visitorMessages,
+				memories,
+				detail: formattedDetail,
+				memorialId,
+			}
+		};
 	} catch (error) {
-		// 오류 처리
-		console.error("데이터 가져오기 중 오류:", error);
+		console.error("Error fetching data:", error);
 		return { notFound: true };
 	}
 };

--- a/pages/detail/[memorialId].tsx
+++ b/pages/detail/[memorialId].tsx
@@ -52,6 +52,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
 		const formattedDetail = {
 			id: detail.id,
+			user_name: detail.user_name,
 			birth_start: detail.birth_start,
 			birth_end: detail.birth_end,
 			career_contents: detail.career_contents,

--- a/pages/detail/[memorialId].tsx
+++ b/pages/detail/[memorialId].tsx
@@ -12,15 +12,15 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 			throw new Error("Params are missing");
 		}
 
-		// userId를 number로 변환
-		const userId = Number(context.params.userId);
+		// memorialId를 number로 변환
+		const memorialId = Number(context.params.memorialId);
 
-		if (isNaN(userId)) {
-			throw new Error("Invalid userId");
+		if (isNaN(memorialId)) {
+			throw new Error("Invalid memorialId");
 		}
 
 		// API 호출
-		const url = `${process.env.NEXT_PUBLIC_API_URL}/api/memorial/${userId}/detail`;
+		const url = `${process.env.NEXT_PUBLIC_API_URL}/api/memorial/${memorialId}/detail`;
 		const response = await fetch(url);
 
 		// API 응답 상태 확인
@@ -52,6 +52,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 						visitorMessages,
 						memories,
 						detail,
+						memorialId,
 					}
 				};
 			} else {


### PR DESCRIPTION
## 배경
- 등록된 기념관의 상세 내용을 확인할 수 있습니다.

## 작업내용
- 기념관 정보, 스토리, 방문객 메시지를 상세페이지에서 조회합니다.

## 테스트방법
- yarn dev 명령어로 로컬 서버를 실행합니다.
- http://localhost:3000/detail/{id} 상세 페이지로 접근합니다.
- 정상적으로 상세 페이지가 나오는 지 확인합니다.

## 리뷰노트
- 기념관 상세 API 에서 '기념인 이름'과 스토리 작성자의 '이름'이 필요합니다.

## 스크린샷
![image.jpg1](https://github.com/Genithlabs/Memorial/assets/15684441/1bf6f7e0-6ba5-4a8c-8a9c-b6d11d9e0797) |![image.jpg2](https://github.com/Genithlabs/Memorial/assets/15684441/c7a520b5-9e3c-4ccc-965e-6c2f79f26290) |![image.jpg3](https://github.com/Genithlabs/Memorial/assets/15684441/0979c8c0-039e-4b0c-8ba0-d4890facff3d)
|--- | --- | --- |

