### PR TITLE
메인의 기념관 리스트를 API와 연동하여 가져옵니다

### DIFF
--- a/components/Main.tsx
+++ b/components/Main.tsx
@@ -9,11 +9,9 @@ import Typography from '@mui/material/Typography';
 import Container from '@mui/material/Container';
 import NextLink from 'next/link';
 import {useSession} from "next-auth/react";
+import {MainProps} from "@/types/main";
 
-
-const cards = [1, 2, 3, 4];
-
-export default function Main() {
+export default function Main({memorialCards}: MainProps) {
 	const  {status} = useSession();
 	const redirectUrl = status === 'authenticated' ? '/form' : '/signin';
 	return (
@@ -92,8 +90,8 @@ export default function Main() {
 					</Typography>
 					{/* End hero unit */}
 					<Grid container spacing={4}>
-						{cards.map((card) => (
-							<Grid item key={card} xs={12} sm={6} md={3}>
+						{memorialCards.map((card) => (
+							<Grid item key={card.id} xs={12} sm={6} md={3}>
 								<Card
 									sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}
 								>
@@ -103,7 +101,7 @@ export default function Main() {
 											// 16:9
 											pt: '56.25%',
 										}}
-										image="https://source.unsplash.com/random?wallpapers"
+										image={card.attachment_profile_image ? `${process.env.NEXT_PUBLIC_IMAGE}${card.attachment_profile_image.file_path}${card.attachment_profile_image.file_name}` : "https://source.unsplash.com/random?wallpapers"}
 									/>
 								</Card>
 							</Grid>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,9 +1,41 @@
 import Main from '../components/Main';
+import {GetServerSideProps} from "next";
+import {MainProps, MemorialCard} from "@/types/main";
 
-export default function main() {
+export default function main(props: MainProps) {
   return (
       <div>
-        <Main />
+        <Main {...props} />
       </div>
   );
 }
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+    try {
+        const url = `${process.env.NEXT_PUBLIC_API_URL}/api/memorial/index`;
+        const response = await fetch(url);
+
+        if (!response.ok) {
+            console.error(`Error fetching data`);
+            return { notFound: true };
+        }
+
+        const result = await response.json();
+        if (result.result !== 'success') {
+            console.error(`Error: `, result.message);
+            return { notFound: true };
+        }
+
+        const memorialCards: MemorialCard[] = result.data.map((item: any) => ({
+            id: item.id,
+            attachment_profile_image: item.attachment_profile_image,
+        }));
+
+        return {
+            props: { memorialCards },
+        };
+    } catch (error) {
+        console.error("Error fetching data:", error);
+        return { notFound: true };
+    }
+};

--- a/types/main.ts
+++ b/types/main.ts
@@ -1,0 +1,11 @@
+export type MemorialCard = {
+    id: number;
+    attachment_profile_image: {
+        file_path: string
+        file_name: string
+    }
+};
+
+export interface MainProps {
+    memorialCards: MemorialCard[];
+}


### PR DESCRIPTION
## 배경
- 메인의 기념관 리스트를 노출합니다.

## 작업내용
- 기념관 리스트 API 를 연동하여 기념관 리스트를 가져옵니다.

## 테스트방법
- yarn dev 명령어로 로컬 서버를 실행합니다.
- 메인 페이지로 이동합니다
- 정상적으로 리스트가 나오는 지 확인합니다.

## 스크린샷
![스크린샷 2024-05-10 오후 7 49 06](https://github.com/Genithlabs/Memorial/assets/15684441/36cee911-724a-4dfc-898d-84fb99737b9f)


