### PR TITLE
방문객 메시지를 작성할 수 있습니다

### DIFF
--- a/components/detail/Life.tsx
+++ b/components/detail/Life.tsx
@@ -3,73 +3,129 @@ import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
 import Box from "@mui/material/Box";
 import TextAreaCustomized from "./TextAreaCustomized";
-import {useState} from "react";
+import { useState, ChangeEvent } from "react";
 import Grow from "@mui/material/Grow";
-import {LifeProps} from "./interfaces";
+import { LifeProps } from "./interfaces";
+import { useSession } from "next-auth/react";
 
-export default function Life({visitorMessages, detail, memorialId}:LifeProps) {
-
+export default function Life({ visitorMessages: initialVisitorMessages, detail, memorialId }: LifeProps) {
+	const [visitorMessages, setVisitorMessages] = useState(initialVisitorMessages);
+	const { data: session } = useSession();
 	const [showTextArea, setShowTextArea] = useState(false);
+	const [message, setMessage] = useState("");
 
-	const handleButtonClick = (flag:boolean) => {
+	const handleButtonClick = (flag: boolean) => {
 		setShowTextArea(flag);
+	};
+
+	const handleRegisterComment = async () => {
+		try {
+			if (session) {
+				if (!message) {
+					alert("메시지를 입력해주세요.")
+					return false;
+				}
+				const url = `${process.env.NEXT_PUBLIC_API_URL}/api/memorial/${memorialId}/comment/register`;
+				const formData = new FormData();
+				formData.append("message", message);
+				const response = await fetch(url, {
+					method: "POST",
+					headers: {
+						Authorization: `Bearer ${session.accessToken}`,
+					},
+					body: formData,
+				});
+				const result = await response.json();
+				if (result.result === "success") {
+					// 새로운 코멘트를 기존 메시지 리스트에 추가
+					setVisitorMessages([...result.data]);
+					setMessage("");
+				}
+			}
+		} catch (error) {
+			console.error("ERROR: ", error);
+		}
+	};
+
+	const handleMessageChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+		setMessage(e.target.value);
 	};
 
 	return (
 		<>
-			<Container sx={{
-				p: "1rem",
-				fontSize: "1rem",
-			}}
-			  className={"diff-card-section"}
+			<Container
+				sx={{
+					p: "1rem",
+					fontSize: "1rem",
+				}}
+				className={"diff-card-section"}
 			>
 				{detail && <div dangerouslySetInnerHTML={{ __html: detail.career_contents }} />}
 			</Container>
 			<Box>
-				<Typography sx={{
-					fontSize: '2rem',
-					fontWeight: 'bold',
-					mt: "5rem",
-				}}>
+				<Typography
+					sx={{
+						fontSize: "2rem",
+						fontWeight: "bold",
+						mt: "5rem",
+					}}
+				>
 					방문객 메시지
 				</Typography>
 
-				{!showTextArea &&
-					<Grow in={!showTextArea}
-                      style={{ transformOrigin: '0 0 0' }}
-				      {...(!showTextArea ? { timeout: 200 } : {})}
+				{!showTextArea && (
+					<Grow
+						in={!showTextArea}
+						style={{ transformOrigin: "0 0 0" }}
+						{...(!showTextArea ? { timeout: 200 } : {})}
 					>
 						<Box>
-                            <Button variant="contained" onClick={() => handleButtonClick(true)}>메시지 쓰기</Button>
-                        </Box>
+							<Button variant="contained" onClick={() => handleButtonClick(true)}>
+								메시지 쓰기
+							</Button>
+						</Box>
 					</Grow>
-				}
+				)}
 
 				{showTextArea && (
-					<Grow in={showTextArea}
-				      style={{ transformOrigin: '0 0 0' }}
-				      {...(showTextArea ? { timeout: 200 } : {})}
+					<Grow
+						in={showTextArea}
+						style={{ transformOrigin: "0 0 0" }}
+						{...(showTextArea ? { timeout: 200 } : {})}
 					>
 						<Box>
-							<TextAreaCustomized placeholder="방문객 메시지를 여기에 작성하세요." />
-							<Box sx={{ textAlign: 'right' }}>
-								<Button variant="contained" color="error" sx={{ mr: '.5rem' }} onClick={() => handleButtonClick(false)}>취소</Button>
-								<Button variant="contained">게시하기</Button>
+							<TextAreaCustomized placeholder="방문객 메시지를 여기에 작성하세요." onChange={handleMessageChange} value={message} />
+							<Box sx={{ textAlign: "right" }}>
+								<Button
+									variant="contained"
+									color="error"
+									sx={{ mr: ".5rem" }}
+									onClick={() => handleButtonClick(false)}
+								>
+									취소
+								</Button>
+								<Button variant="contained" onClick={handleRegisterComment}>
+									게시하기
+								</Button>
 							</Box>
 						</Box>
 					</Grow>
 				)}
 			</Box>
 			<Box sx={{ mt: "1rem" }}>
-				{visitorMessages?.map(({created_at, message, user_name}, index) => {
+				{visitorMessages?.map(({ created_at, message, user_name }, index) => {
 					const date = new Date(created_at);
 					const formattedDate = `${date.getMonth() + 1}월 ${date.getDate()}일`;
 
 					return (
-						<Box key={index} sx={{ p: '1rem', mt: index !== 0 ? '2rem' : '0' }} className={"diff-card-section"}>
-							<div style={{display:"flex"}}>
+						<Box
+							key={index}
+							sx={{ p: "1rem", mt: index !== 0 ? "2rem" : "0" }}
+							className={"diff-card-section"}
+						>
+							<div style={{ display: "flex" }}>
 								<Typography>{user_name}</Typography>
-								<Typography sx={{ p: "0 .5rem"}}>•</Typography>
+								<Typography sx={{ p: "0 .5rem" }}>•</Typography>
 								<Typography>{formattedDate}</Typography>
 							</div>
 							<div>

--- a/components/detail/TextAreaCustomized.tsx
+++ b/components/detail/TextAreaCustomized.tsx
@@ -1,60 +1,69 @@
+import React, { memo, useCallback } from 'react';
 import { TextareaAutosize } from '@mui/base/TextareaAutosize';
 import { styled } from '@mui/system';
 
-export default function TextAreaCustomized({ placeholder }: { placeholder: string }) {
-	const blue = {
-		100: '#DAECFF',
-		200: '#b6daff',
-		400: '#3399FF',
-		500: '#007FFF',
-		600: '#0072E5',
-		900: '#003A75',
-	};
-
-	const grey = {
-		50: '#f6f8fa',
-		100: '#eaeef2',
-		200: '#d0d7de',
-		300: '#afb8c1',
-		400: '#8c959f',
-		500: '#6e7781',
-		600: '#57606a',
-		700: '#424a53',
-		800: '#32383f',
-		900: '#24292f',
-	};
-
-	const StyledTextarea = styled(TextareaAutosize)(
-		({ theme }) => `
-    width: 100%;
-    font-family: IBM Plex Sans, sans-serif;
-    font-size: 0.875rem;
-    font-weight: 400;
-    line-height: 1.5;
-    padding: 12px;
-    border-radius: 12px 12px 0 12px;
-    color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};
-    background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
-    border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
-    box-shadow: 0px 2px 24px ${
-			theme.palette.mode === 'dark' ? blue[900] : blue[100]
-		};
-
-    &:hover {
-      border-color: ${blue[400]};
-    }
-
-    &:focus {
-      border-color: ${blue[400]};
-      box-shadow: 0 0 0 3px ${theme.palette.mode === 'dark' ? blue[600] : blue[200]};
-    }
-
-    // firefox
-    &:focus-visible {
-      outline: 0;
-    }
-  `,
-	);
-
-	return <StyledTextarea minRows={3} aria-label="empty textarea" placeholder={placeholder} />
+interface TextAreaCustomizedProps {
+	placeholder: string;
+	onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
+	value: string;
 }
+
+const blue = {
+	100: '#DAECFF',
+	200: '#b6daff',
+	400: '#3399FF',
+	500: '#007FFF',
+	600: '#0072E5',
+	900: '#003A75',
+};
+
+const grey = {
+	50: '#f6f8fa',
+	100: '#eaeef2',
+	200: '#d0d7de',
+	300: '#afb8c1',
+	400: '#8c959f',
+	500: '#6e7781',
+	600: '#57606a',
+	700: '#424a53',
+	800: '#32383f',
+	900: '#24292f',
+};
+
+const StyledTextarea = styled(TextareaAutosize)(({ theme }) => `
+  width: 100%;
+  font-family: IBM Plex Sans, sans-serif;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.5;
+  padding: 12px;
+  border-radius: 12px 12px 0 12px;
+  color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};
+  background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
+  border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
+  box-shadow: 0px 2px 24px ${theme.palette.mode === 'dark' ? blue[900] : blue[100]};
+
+  &:hover {
+    border-color: ${blue[400]};
+  }
+
+  &:focus {
+    border-color: ${blue[400]};
+    box-shadow: 0 0 0 3px ${theme.palette.mode === 'dark' ? blue[600] : blue[200]};
+  }
+
+  &:focus-visible {
+    outline: 0;
+  }
+`);
+
+// eslint-disable-next-line react/display-name
+const TextAreaCustomized = memo(({ placeholder, onChange, value }: TextAreaCustomizedProps) => {
+	const handleChange = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
+		onChange(event);
+	}, [onChange]);
+
+	return <StyledTextarea minRows={3} aria-label="empty textarea" placeholder={placeholder} onChange={handleChange} value={value} />;
+});
+
+export default TextAreaCustomized;


### PR DESCRIPTION
## 배경
- 기념관 상세 페이지에서 방문객이 메시지를 남길 수 있어야 합니다.

## 작업내용
- 방문객 메시지 작성 API 를 연동합니다.
- 화면상에 방문객 메시지 리스트를 API 결과값의 data(방문객 메시지 리스트)로 업데이트 합니다.

## 테스트방법
- yarn dev 명령어로 로컬 서버를 실행합니다.
- 기념관 상세로 이동합니다. (ex. http://localhost:3000/detail/1)
- 하단의 '메시지 쓰기' 버튼을 클릭하고 메시지를 작성 후 '게시하기' 버튼을 눌러 정상적으로 작성되는 지 확인합니다.

## 스크린샷
![화면 기록 2024-05-11 오후 2 08 41](https://github.com/Genithlabs/Memorial/assets/15684441/f0f47e6c-87f8-4e74-b54d-c21ad26c1d8a)





