### PR TITLE
추억 & 메시지를 남길 수 있습니다.

### DIFF
--- a/components/detail/Memory.tsx
+++ b/components/detail/Memory.tsx
@@ -6,8 +6,8 @@ import MemoryForm from "@/components/detail/MemoryForm";
 import Grow from "@mui/material/Grow";
 import {MemoryProps} from "./interfaces";
 
-export default function Memory({ memories, memorialId }: MemoryProps) {
-
+export default function Memory({ memories: initialMemories, memorialId }: MemoryProps) {
+	const [memories, setMemories] = useState(initialMemories);
 	const [showFrom, setShowFormArea] = useState(false);
 	const [initialLoad, setInitialLoad] = useState(true);  // 처음 로드 여부를 확인하는 상태
 
@@ -49,25 +49,35 @@ export default function Memory({ memories, memorialId }: MemoryProps) {
 	                    }}
                           className={"diff-card-section"}
                         >
-							<MemoryForm onHideForm={handleHideForm} />
+							<MemoryForm onHideForm={handleHideForm} memorialId={memorialId} setMemories={setMemories}/>
                         </Box>
                     </Grow>
 			   }
 			</Box>
 			<Box sx={{ mt: "1rem" }}>
-				{memories.map(({created_at, message, user_name}, index) => {
+				{memories.map(({created_at, message, user_name, attachment}, index) => {
 					const date = new Date(created_at);
 					const formattedDate = `${date.getMonth() + 1}월 ${date.getDate()}일`;
 
 					return (
 						<Box key={index} sx={{ p: '1rem', mt: index !== 0 ? '2rem' : '0' }} className={"diff-card-section"}>
 							<div style={{display:"flex"}}>
-								<Typography>{user_name || "이름"}</Typography>
+								<Typography>{user_name ?? '이름'}</Typography>
 								<Typography sx={{ p: "0 .5rem"}}>•</Typography>
 								<Typography>{formattedDate}</Typography>
 							</div>
 							<div>
 								<div dangerouslySetInnerHTML={{ __html: message }} />
+								{attachment && (
+									/\.(jpg|jpeg|png)$/i.test(attachment.file_name) ? (
+										<img src={`${process.env.NEXT_PUBLIC_IMAGE}${attachment.file_path}${attachment.file_name}`} alt="Memory Image" style={{ width: '100%', marginTop: '1rem' }} />
+									) : /\.(mp4|mov)$/i.test(attachment.file_name) ? (
+										<video controls style={{ width: '100%', marginTop: '1rem' }}>
+											<source src={`${process.env.NEXT_PUBLIC_IMAGE}${attachment.file_path}${attachment.file_name}`} type="video/mp4" />
+											Your browser does not support the video tag.
+										</video>
+									) : null
+								)}
 							</div>
 						</Box>
 					);

--- a/components/detail/TextAreaCustomized.tsx
+++ b/components/detail/TextAreaCustomized.tsx
@@ -1,60 +1,69 @@
+import React, { memo, useCallback } from 'react';
 import { TextareaAutosize } from '@mui/base/TextareaAutosize';
 import { styled } from '@mui/system';
 
-export default function TextAreaCustomized({ placeholder }: { placeholder: string }) {
-	const blue = {
-		100: '#DAECFF',
-		200: '#b6daff',
-		400: '#3399FF',
-		500: '#007FFF',
-		600: '#0072E5',
-		900: '#003A75',
-	};
-
-	const grey = {
-		50: '#f6f8fa',
-		100: '#eaeef2',
-		200: '#d0d7de',
-		300: '#afb8c1',
-		400: '#8c959f',
-		500: '#6e7781',
-		600: '#57606a',
-		700: '#424a53',
-		800: '#32383f',
-		900: '#24292f',
-	};
-
-	const StyledTextarea = styled(TextareaAutosize)(
-		({ theme }) => `
-    width: 100%;
-    font-family: IBM Plex Sans, sans-serif;
-    font-size: 0.875rem;
-    font-weight: 400;
-    line-height: 1.5;
-    padding: 12px;
-    border-radius: 12px 12px 0 12px;
-    color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};
-    background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
-    border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
-    box-shadow: 0px 2px 24px ${
-			theme.palette.mode === 'dark' ? blue[900] : blue[100]
-		};
-
-    &:hover {
-      border-color: ${blue[400]};
-    }
-
-    &:focus {
-      border-color: ${blue[400]};
-      box-shadow: 0 0 0 3px ${theme.palette.mode === 'dark' ? blue[600] : blue[200]};
-    }
-
-    // firefox
-    &:focus-visible {
-      outline: 0;
-    }
-  `,
-	);
-
-	return <StyledTextarea minRows={3} aria-label="empty textarea" placeholder={placeholder} />
+interface TextAreaCustomizedProps {
+	placeholder: string;
+	onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
+	value: string;
 }
+
+const blue = {
+	100: '#DAECFF',
+	200: '#b6daff',
+	400: '#3399FF',
+	500: '#007FFF',
+	600: '#0072E5',
+	900: '#003A75',
+};
+
+const grey = {
+	50: '#f6f8fa',
+	100: '#eaeef2',
+	200: '#d0d7de',
+	300: '#afb8c1',
+	400: '#8c959f',
+	500: '#6e7781',
+	600: '#57606a',
+	700: '#424a53',
+	800: '#32383f',
+	900: '#24292f',
+};
+
+const StyledTextarea = styled(TextareaAutosize)(({ theme }) => `
+  width: 100%;
+  font-family: IBM Plex Sans, sans-serif;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.5;
+  padding: 12px;
+  border-radius: 12px 12px 0 12px;
+  color: ${theme.palette.mode === 'dark' ? grey[300] : grey[900]};
+  background: ${theme.palette.mode === 'dark' ? grey[900] : '#fff'};
+  border: 1px solid ${theme.palette.mode === 'dark' ? grey[700] : grey[200]};
+  box-shadow: 0px 2px 24px ${theme.palette.mode === 'dark' ? blue[900] : blue[100]};
+
+  &:hover {
+    border-color: ${blue[400]};
+  }
+
+  &:focus {
+    border-color: ${blue[400]};
+    box-shadow: 0 0 0 3px ${theme.palette.mode === 'dark' ? blue[600] : blue[200]};
+  }
+
+  &:focus-visible {
+    outline: 0;
+  }
+`);
+
+// eslint-disable-next-line react/display-name
+const TextAreaCustomized = memo(({ placeholder, onChange, value }: TextAreaCustomizedProps) => {
+	const handleChange = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
+		onChange(event);
+	}, [onChange]);
+
+	return <StyledTextarea minRows={3} aria-label="empty textarea" placeholder={placeholder} onChange={handleChange} value={value} />;
+});
+
+export default TextAreaCustomized;

--- a/components/detail/interfaces.ts
+++ b/components/detail/interfaces.ts
@@ -20,6 +20,11 @@ export interface Memory {
 	is_visible: number
 	created_at: string
 	updated_at: string
+	attachment: {
+		id: number
+		file_name: string
+		file_path: string
+	}|null
 }
 
 export interface AttachmentProfileImage {


### PR DESCRIPTION
## 배경
- 추억 & 메시지를 남길 수 있어야 합니다.

## 작업내용
- 추억 & 메시지 작성 API 를 연동합니다.
- 화면상에 추억 & 메시지 리스트를 API 결과값의 data(추억 & 메시지 리스트)로 업데이트 합니다.

## 테스트방법
- yarn dev 명령어로 로컬 서버를 실행합니다.
- 기념관 상세로 이동합니다. (ex. http://localhost:3000/detail/1)
- '추억과 메시지' 탭으로 이동 후 '추억 & 메시지 남기기' 버튼을 클릭하여 제목, 내용, 파일(이미지 or 영상) 작성 후 '게시하기' 버튼을 눌러 정상적으로 작성되는 지 확인합니다.

## 스크린샷
![화면 기록 2024-05-12 오후 1 45 31 (1)](https://github.com/Genithlabs/Memorial/assets/15684441/0476a16a-6db2-432b-8814-2191f7376445)







