### PR TITLE
로그인 후 form 으로 리다이렉트 되도록 수정합니다

### DIFF
--- a/components/Form.tsx
+++ b/components/Form.tsx
@@ -48,32 +48,37 @@ export default function Form() {
 	const [memorialId, setMemorialId] = useState("");
 
 	useEffect(() => {
-		const fetchView = async () => {
-			if (session) {
-				const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/memorial/view`, {
-					method: 'GET',
-					headers: {
-						'Authorization': `Bearer ${session.accessToken}`
-					},
-				});
-				if (response.ok) {
-					const result = await response.json();
-					if (result.result === 'success' && result.data) {
-						const data = result.data;
-						const updatedBasicInfo = {
-							...basicInfo,
-							user_name: data.name,
-							profile: data.profile_attachment_id ? `${process.env.NEXT_PUBLIC_IMAGE}${data.attachment_profile_image.file_path}${data.attachment_profile_image.file_name}` : '',
-							bgm: data.bgm_attachment_id ? `${process.env.NEXT_PUBLIC_IMAGE}${data.attachment_bgm.file_path}${data.attachment_bgm.file_name}` : ''
-						};
-						setBasicInfo(updatedBasicInfo);
-						setContent(data.career_contents);
-						setMemorialId(data.id);
+		if (!session) {
+			alert('로그인 후 이용 가능합니다.');
+			router.push('/signin');
+		} else {
+			const fetchView = async () => {
+				if (session) {
+					const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/memorial/view`, {
+						method: 'GET',
+						headers: {
+							'Authorization': `Bearer ${session.accessToken}`
+						},
+					});
+					if (response.ok) {
+						const result = await response.json();
+						if (result.result === 'success' && result.data) {
+							const data = result.data;
+							const updatedBasicInfo = {
+								...basicInfo,
+								user_name: data.name,
+								profile: data.profile_attachment_id ? `${process.env.NEXT_PUBLIC_IMAGE}${data.attachment_profile_image.file_path}${data.attachment_profile_image.file_name}` : '',
+								bgm: data.bgm_attachment_id ? `${process.env.NEXT_PUBLIC_IMAGE}${data.attachment_bgm.file_path}${data.attachment_bgm.file_name}` : ''
+							};
+							setBasicInfo(updatedBasicInfo);
+							setContent(data.career_contents);
+							setMemorialId(data.id);
+						}
 					}
 				}
 			}
+			fetchView();
 		}
-		fetchView();
 	}, []);
 
 

--- a/components/Form.tsx
+++ b/components/Form.tsx
@@ -48,37 +48,32 @@ export default function Form() {
 	const [memorialId, setMemorialId] = useState("");
 
 	useEffect(() => {
-		if (!session) {
-			alert('로그인 후 이용 가능합니다.');
-			router.push('/signin');
-		} else {
-			const fetchView = async () => {
-				if (session) {
-					const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/memorial/view`, {
-						method: 'GET',
-						headers: {
-							'Authorization': `Bearer ${session.accessToken}`
-						},
-					});
-					if (response.ok) {
-						const result = await response.json();
-						if (result.result === 'success' && result.data) {
-							const data = result.data;
-							const updatedBasicInfo = {
-								...basicInfo,
-								user_name: data.name,
-								profile: data.profile_attachment_id ? `${process.env.NEXT_PUBLIC_IMAGE}${data.attachment_profile_image.file_path}${data.attachment_profile_image.file_name}` : '',
-								bgm: data.bgm_attachment_id ? `${process.env.NEXT_PUBLIC_IMAGE}${data.attachment_bgm.file_path}${data.attachment_bgm.file_name}` : ''
-							};
-							setBasicInfo(updatedBasicInfo);
-							setContent(data.career_contents);
-							setMemorialId(data.id);
-						}
+		const fetchView = async () => {
+			if (session) {
+				const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/memorial/view`, {
+					method: 'GET',
+					headers: {
+						'Authorization': `Bearer ${session.accessToken}`
+					},
+				});
+				if (response.ok) {
+					const result = await response.json();
+					if (result.result === 'success' && result.data) {
+						const data = result.data;
+						const updatedBasicInfo = {
+							...basicInfo,
+							user_name: data.name,
+							profile: data.profile_attachment_id ? `${process.env.NEXT_PUBLIC_IMAGE}${data.attachment_profile_image.file_path}${data.attachment_profile_image.file_name}` : '',
+							bgm: data.bgm_attachment_id ? `${process.env.NEXT_PUBLIC_IMAGE}${data.attachment_bgm.file_path}${data.attachment_bgm.file_name}` : ''
+						};
+						setBasicInfo(updatedBasicInfo);
+						setContent(data.career_contents);
+						setMemorialId(data.id);
 					}
 				}
 			}
-			fetchView();
 		}
+		fetchView();
 	}, []);
 
 
@@ -140,6 +135,10 @@ export default function Form() {
 		setActiveStep(activeStep - 1);
 	};
 
+	const handleStepClick = (step: number) => {
+		setActiveStep(step);
+	};
+
 	return (
 		<>
 			<Container component="main" maxWidth="sm" sx={{ mb: 4 }}>
@@ -148,8 +147,8 @@ export default function Form() {
 						인생 기념관 만들기
 					</Typography>
 					<Stepper activeStep={activeStep} sx={{ pt: 3, pb: 5,  }}>
-						{steps.map((label) => (
-							<Step key={label}>
+						{steps.map((label, index) => (
+							<Step key={label} onClick={() => handleStepClick(index)} completed={false}>
 								<StepLabel>{label}</StepLabel>
 							</Step>
 						))}

--- a/components/SignIn.tsx
+++ b/components/SignIn.tsx
@@ -2,7 +2,7 @@ import Container from '@mui/material/Container';
 import Avatar from '@mui/material/Avatar';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import Typography from '@mui/material/Typography';
-import {Link as MUILink} from '@mui/material';
+import { Link as MUILink } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
@@ -10,20 +10,25 @@ import Button from '@mui/material/Button';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Checkbox from '@mui/material/Checkbox';
 import NextLink from 'next/link';
-import {signIn, useSession} from "next-auth/react";
-import {useRouter} from "next/router";
-import {useEffect} from "react";
-
+import { signIn, useSession } from "next-auth/react";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
 
 export default function SignIn() {
-	const {data: session} = useSession();
+	const { data: session } = useSession();
 	const router = useRouter();
+	const [isMounted, setIsMounted] = useState(false);
 
 	useEffect(() => {
 		if (session) {
 			router.push('/');
 		}
 	}, [session, router]);
+
+	useEffect(() => {
+		setIsMounted(true);
+	}, []);
+
 	const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
 		const data = new FormData(event.currentTarget);
@@ -37,87 +42,91 @@ export default function SignIn() {
 		});
 
 		if (result?.ok) {
-			router.push('/');
+			router.push('/form');
+		} else {
+			alert('로그인 실패!');
 		}
 	};
 
+	if (!isMounted) {
+		return null;
+	}
+
 	return (
-		<>
-			<Container component="main" maxWidth="xs">
-				<Box
-					sx={{
-						marginTop: 8,
-						display: 'flex',
-						flexDirection: 'column',
-						alignItems: 'center',
-					}}
-				>
-					<Avatar sx={{ m: 1, bgcolor: 'secondary.main' }}>
-						<LockOutlinedIcon />
-					</Avatar>
-					<Typography component="h1" variant="h5">
-						Sign in
-					</Typography>
-					<Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1 }}>
-						<TextField
-							margin="normal"
-							required
-							fullWidth
-							id="user_id"
-							label="ID"
-							name="user_id"
-							autoComplete="ID"
-							autoFocus
-						/>
-						<TextField
-							margin="normal"
-							required
-							fullWidth
-							name="password"
-							label="Password"
-							type="password"
-							id="password"
-							autoComplete="current-password"
-						/>
-						<FormControlLabel
-							control={<Checkbox value="remember" color="primary" />}
-							label="Remember me"
-						/>
-						<Button
-							type="submit"
-							fullWidth
-							variant="contained"
-							sx={{ mt: 3, mb: 2 }}
-						>
-							Sign In
-						</Button>
-						<Grid container justifyContent="space-between" alignItems="center">
-							<Grid item>
-								<Typography variant="body2">
-									<NextLink href="/findId" passHref>
-										<MUILink>
-											아이디 찾기
-										</MUILink>
-									</NextLink>
-									{' / '}
-									<NextLink href="/find-password" passHref>
-										<MUILink>
-											패스워드 찾기
-										</MUILink>
-									</NextLink>
-								</Typography>
-							</Grid>
-							<Grid item>
-								<NextLink href="/signup" passHref>
-									<MUILink variant="body2">
-										회원가입
+		<Container component="main" maxWidth="xs">
+			<Box
+				sx={{
+					marginTop: 8,
+					display: 'flex',
+					flexDirection: 'column',
+					alignItems: 'center',
+				}}
+			>
+				<Avatar sx={{ m: 1, bgcolor: 'secondary.main' }}>
+					<LockOutlinedIcon />
+				</Avatar>
+				<Typography component="h1" variant="h5">
+					Sign in
+				</Typography>
+				<Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1 }}>
+					<TextField
+						margin="normal"
+						required
+						fullWidth
+						id="user_id"
+						label="ID"
+						name="user_id"
+						autoComplete="ID"
+						autoFocus
+					/>
+					<TextField
+						margin="normal"
+						required
+						fullWidth
+						name="password"
+						label="Password"
+						type="password"
+						id="password"
+						autoComplete="current-password"
+					/>
+					<FormControlLabel
+						control={<Checkbox value="remember" color="primary" />}
+						label="Remember me"
+					/>
+					<Button
+						type="submit"
+						fullWidth
+						variant="contained"
+						sx={{ mt: 3, mb: 2 }}
+					>
+						Sign In
+					</Button>
+					<Grid container justifyContent="space-between" alignItems="center">
+						<Grid item>
+							<Typography variant="body2">
+								<NextLink href="/findId" passHref>
+									<MUILink>
+										아이디 찾기
 									</MUILink>
 								</NextLink>
-							</Grid>
+								{' / '}
+								<NextLink href="/find-password" passHref>
+									<MUILink>
+										패스워드 찾기
+									</MUILink>
+								</NextLink>
+							</Typography>
 						</Grid>
-					</Box>
+						<Grid item>
+							<NextLink href="/signup" passHref>
+								<MUILink variant="body2">
+									회원가입
+								</MUILink>
+							</NextLink>
+						</Grid>
+					</Grid>
 				</Box>
-			</Container>
-		</>
+			</Box>
+		</Container>
 	);
 }

--- a/components/SignIn.tsx
+++ b/components/SignIn.tsx
@@ -21,7 +21,7 @@ export default function SignIn() {
 
 	useEffect(() => {
 		if (session) {
-			router.push('/');
+			router.push('/form');
 		}
 	}, [session, router]);
 


### PR DESCRIPTION
## 배경
- 로그인 후 기념관 설립 페이지로 이동 되어야 합니다.
- https://www.notion.so/mininc/5e32af0eb645483a94e330e5bcf613a5

## 작업내용
- 로그인 안된 상태로 기념관 설립 페이지 이동 시 로그인 페이지로 리다이렉트 되도록 수정합니다.
- 로그인 후 기념관 설립 페이지로 이동 되도록 수정합니다.

## 테스트방법
- yarn dev 명령어로 로컬 서버를 실행합니다.
- 로그인 안된 상태로 기념관 설립 페이지로 이동합니다.
- `로그인 후 이용 가능합니다.` alert 확인 후 로그인 페이지로 리다이렉트 되는지 확인합니다.
- 로그인 후 기념관 설립 페이지로 이동 되는지 확인합니다.






