### PR TITLE
메인의 기념관 리스트 클릭 시 기념관으로 이동되도록 수정합니다

### DIFF
--- a/components/Main.tsx
+++ b/components/Main.tsx
@@ -92,18 +92,20 @@ export default function Main({memorialCards}: MainProps) {
 					<Grid container spacing={4}>
 						{memorialCards.map((card) => (
 							<Grid item key={card.id} xs={12} sm={6} md={3}>
-								<Card
-									sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}
-								>
-									<CardMedia
-										component="div"
-										sx={{
-											// 16:9
-											pt: '56.25%',
-										}}
-										image={card.attachment_profile_image ? `${process.env.NEXT_PUBLIC_IMAGE}${card.attachment_profile_image.file_path}${card.attachment_profile_image.file_name}` : "https://source.unsplash.com/random?wallpapers"}
-									/>
-								</Card>
+								<NextLink href={`/detail/${card.id}`} passHref>
+									<Card
+										sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}
+									>
+										<CardMedia
+											component="div"
+											sx={{
+												// 16:9
+												pt: '56.25%',
+											}}
+											image={card.attachment_profile_image ? `${process.env.NEXT_PUBLIC_IMAGE}${card.attachment_profile_image.file_path}${card.attachment_profile_image.file_name}` : "https://source.unsplash.com/random?wallpapers"}
+										/>
+									</Card>
+								</NextLink>
 							</Grid>
 						))}
 					</Grid>


### PR DESCRIPTION
## 배경
- [기념관 건립시 기념관 리스트에 표시되도록 하고, 클릭시 해당 기념관 상세페이지로 이동하게 합니다. ](https://www.notion.so/mininc/d50e084616b1494e93da55f196742115?v=8956f1b6fe50418ca6a7c654822c1191&p=67577ada1ff64b1fa6c2f1ece31b548b&pm=s)

## 작업내용
- 커곧내

## 테스트방법
- yarn dev 명령어로 로컬 서버를 실행합니다.
- main 에 기념관 리스트가 나오는지 확인합니다.
- 기념관 리스트 클릭 시 기념관으로 이동하는지 확인합니다.