### PR TITLE
기념관 관련 QA 이슈를 수정합니다.

### DIFF
--- a/components/Detail.tsx
+++ b/components/Detail.tsx
@@ -23,14 +23,23 @@ export default function Detail({ visitorMessages: initialVisitorMessages, memori
 	const [visitorMessages, setVisitorMessages] = useState(initialVisitorMessages);
 
 	useEffect(() => {
+		let audioElement: HTMLAudioElement | null = null;
 		if (detail.attachment_bgm) {
-			const audioElement = new Audio(`${process.env.NEXT_PUBLIC_IMAGE}${detail.attachment_bgm.file_path}${detail.attachment_bgm.file_name}`);
+			audioElement = new Audio(`${process.env.NEXT_PUBLIC_IMAGE}${detail.attachment_bgm.file_path}${detail.attachment_bgm.file_name}`);
 			audioElement.addEventListener('ended', () => {
-				audioElement.currentTime = 0;
-				audioElement.play();
+				if (audioElement) {
+					audioElement.currentTime = 0;
+					audioElement.play();
+				}
 			});
 			setAudio(audioElement);
 		}
+		return () => {
+			if (audioElement) {
+				audioElement.pause();
+				audioElement = null;
+			}
+		};
 	}, [detail.attachment_bgm]);
 
 	const togglePlay = () => {

--- a/components/Detail.tsx
+++ b/components/Detail.tsx
@@ -10,13 +10,13 @@ import PauseIcon from '@mui/icons-material/Pause';
 
 const getYearFromDate = (dateStr: string): string => {
 	const date = new Date(dateStr);
-	return date.getFullYear().toString();
+	return `${date.getFullYear().toString()}. ${date.getMonth()+1}`;
 }
 
 export default function Detail({ visitorMessages: initialVisitorMessages, memories: initialMemories, detail, memorialId }: ALLProps) {
 	// Extract only the year from birth_start and birth_end
-	const birthStartYear = getYearFromDate(detail.birth_start);
-	const birthEndYear = detail.birth_end ? getYearFromDate(detail.birth_end) : '';
+	const birthStart = getYearFromDate(detail.birth_start);
+	const birthEnd = detail.birth_end ? getYearFromDate(detail.birth_end) : '';
 	const [isPlaying, setIsPlaying] = useState(false);
 	const [audio, setAudio] = useState<HTMLAudioElement | null>(null);
 	const [memories, setMemories] = useState(initialMemories);
@@ -143,7 +143,7 @@ export default function Detail({ visitorMessages: initialVisitorMessages, memori
 							fontWeight: '400',
 						}}
 					>
-						{birthEndYear ? `${birthStartYear} ~ ${birthEndYear}` : birthStartYear}
+						{birthEnd ? `${birthStart} ~ ${birthStart}` : birthStart}
 					</Typography>
 				</Container>
 				<Container sx={{ mt: {xs:"5rem", sm: "7.5rem", md: "10rem"} }}>

--- a/components/detail/Memory.tsx
+++ b/components/detail/Memory.tsx
@@ -70,11 +70,24 @@ export default function Memory({ memories: initialMemories, memorialId, setMemor
 								<div dangerouslySetInnerHTML={{ __html: message }} />
 								{attachment && (
 									/\.(jpg|jpeg|png)$/i.test(attachment.file_name) ? (
-										<img src={`${process.env.NEXT_PUBLIC_IMAGE}${attachment.file_path}${attachment.file_name}`} alt="Memory Image" style={{ width: '100%', marginTop: '1rem' }} />
+										<img
+											src={`${process.env.NEXT_PUBLIC_IMAGE}${attachment.file_path}${attachment.file_name}`}
+											alt="Memory Image"
+											style={{ width: '100%', marginTop: '1rem' }}
+										/>
 									) : /\.(mp4|mov)$/i.test(attachment.file_name) ? (
 										<video controls style={{ width: '100%', marginTop: '1rem' }}>
-											<source src={`${process.env.NEXT_PUBLIC_IMAGE}${attachment.file_path}${attachment.file_name}`} type="video/mp4" />
-											Your browser does not support the video tag.
+											<source
+												src={`${process.env.NEXT_PUBLIC_IMAGE}${attachment.file_path}${attachment.file_name}`}
+												type="video/mp4"
+											/>
+										</video>
+									) : /\.(mp3)$/i.test(attachment.file_name) ? (
+										<video controls style={{ width: '100%', marginTop: '1rem', height: '60px' }}>
+											<source
+												src={`${process.env.NEXT_PUBLIC_IMAGE}${attachment.file_path}${attachment.file_name}`}
+												type="audio/mp3"
+											/>
 										</video>
 									) : null
 								)}


### PR DESCRIPTION
## 배경[이슈내용]
- [추억&메시지 남기기할 때, 음성파일(mpa)을 업로드 시도하면, 스토리 생성은 성공했다고 하는데 텍스트만 업로드될 뿐 음성은 업로드 되지 않습니다. ](https://www.notion.so/mininc/mpa-34faaee4626646d09e9f013366cf9af4)
- [기념관 음악을 재생하면, 음악이 멈춰지지 않습니다. 메인페이지로 가도 계속 음악이 재생됩니다](https://www.notion.so/mininc/5bac37bec316421e8a977360b014e0f8)
- [생년월일을 모두 입력했는데도 기념관 화면에서 생년까지만 표시됩니다](https://www.notion.so/mininc/95f9763a28b14c1c9bfea8f89602d30c)
- [추억 메시지 남기기에서 음원파일을 업로드해도, 음원파일이 표시되지 않습니다. ](https://www.notion.so/mininc/87b9cbf44b9d4cbfa41631019cc381df)

## 작업내용
- 커곧내

## 테스트방법
- yarn dev 명령어로 로컬 서버를 실행합니다.
- 기념관 음악 재생 후 홈으로 이동 시 음악이 계속 재생되는지 확인합니다.
- 스토리에 mp3 파일 업로드 시 mp3 재생 영역이 나오는지 확인합니다.
- 기념관에 생년과 월이 표시되는지 확안합니다.