### PR TITLE
로그인 실패 문구를 수정하고 header에 로그인/로그아웃 버튼을 생성합니다.

### DIFF
--- a/components/SignIn.tsx
+++ b/components/SignIn.tsx
@@ -44,7 +44,7 @@ export default function SignIn() {
 		if (result?.ok) {
 			router.push('/form');
 		} else {
-			alert('로그인 실패!');
+			alert('아이디 또는 비밀번호를 다시 확인해주세요.');
 		}
 	};
 

--- a/components/common/Header.tsx
+++ b/components/common/Header.tsx
@@ -1,24 +1,35 @@
+import { useSession, signOut } from "next-auth/react";
 import Toolbar from "@mui/material/Toolbar";
 import CameraIcon from "@mui/icons-material/PhotoCamera";
 import Typography from "@mui/material/Typography";
 import AppBar from "@mui/material/AppBar";
+import Button from "@mui/material/Button";
 import Link from "next/link";
 
 export default function Header() {
+	const { data: session, status } = useSession();
+
 	return (
-		<>
-			<AppBar position="relative">
-				<Toolbar>
-					<Link href={"/"}>
-	                    <span style={{ display: 'flex', alignItems: 'center' }}>
-		                    <CameraIcon sx={{ mr: 2 }} />
-		                    <Typography variant="h6" color="inherit" noWrap>
-		                        인생 기념관
-		                    </Typography>
-	                    </span>
-					</Link>
-				</Toolbar>
-			</AppBar>
-		</>
-	)
+		<AppBar position="relative">
+			<Toolbar>
+				<Link href="/" passHref>
+					<span style={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}>
+						<CameraIcon sx={{ mr: 2 }} />
+						<Typography variant="h6" color="inherit" noWrap>
+							인생 기념관
+						</Typography>
+					</span>
+				</Link>
+				<div style={{ marginLeft: 'auto' }}>
+					{status === "authenticated" ? (
+						<Button color="inherit" onClick={() => signOut({ callbackUrl: '/' })}>로그아웃</Button>
+					) : (
+						<Link href="/signin" passHref>
+							<Button color="inherit">로그인</Button>
+						</Link>
+					)}
+				</div>
+			</Toolbar>
+		</AppBar>
+	);
 }


### PR DESCRIPTION
## 배경[이슈내용]
- [Header 에 로그인/로그아웃 버튼을 생성합니다.](https://www.notion.so/mininc/c3b82eac57e549deb333afca94c53d68)
- [로그인 실패 문구를 수정합니다.](https://www.notion.so/mininc/5fac9946acd04379b6603a06dac06120)

## 작업내용
- 커곧내

## 테스트방법
- yarn dev 명령어로 로컬 서버를 실행합니다.
- header 에 로그인/로그아웃 버튼이 나오는 지 확인합니다.
- header 에 로그인/로그아웃 버튼이 정상적으로 작동하는지 확인합니다.
- 로그인 실패 시 "아이디 또는 비밀번호를 다시 확인해주세요" alert 이 나오는지 확인합니다.