### PR TITLE
기념관 리스트 PC 버전에서만 슬라이드 되도록 수정합니다

### DIFF
--- a/components/Main.tsx
+++ b/components/Main.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
 import CardMedia from '@mui/material/CardMedia';
@@ -8,72 +9,167 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Container from '@mui/material/Container';
 import NextLink from 'next/link';
-import {useSession} from "next-auth/react";
-import {MainProps} from "@/types/main";
+import { useSession } from 'next-auth/react';
+import Slider from 'react-slick';
+import { MainProps } from '@/types/main';
+import 'slick-carousel/slick/slick.css';
+import 'slick-carousel/slick/slick-theme.css';
+import { useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import ArrowBackIos from '@mui/icons-material/ArrowBackIos';
+import ArrowForwardIos from '@mui/icons-material/ArrowForwardIos';
 
-export default function Main({memorialCards}: MainProps) {
-	const  {status} = useSession();
-	const redirectUrl = status === 'authenticated' ? '/form' : '/signin';
+const NextArrow = (props: any) => {
+	const { className, style, onClick } = props;
 	return (
-		<>
-			<main>
-				{/* Hero unit */}
-				<Box
-					sx={{
-						bgcolor: 'background.paper',
-						pt: 8,
-						pb: 6,
-					}}
-				>
-					<Container maxWidth="md">
-						<Typography
-							component="h1"
-							align="center"
-							color="text.primary"
-							gutterBottom
-							sx={{
-								fontSize: {
-									xs: '2rem',  // extra-small devices에서의 폰트 크기
-									sm: '2.5rem', // small devices에서의 폰트 크기
-									md: '4rem'  // medium devices에서의 폰트 크기
-								},
-								fontWeight: 300
-							}}
-						>
-							기념관 만들기!
-						</Typography>
-						<Typography
-							align="center"
-							color="text.secondary"
-							paragraph
-							sx={{
-								fontSize: {
-									xs: '.9rem',  // extra-small devices에서의 폰트 크기
-									sm: '1.5rem', // small devices에서의 폰트 크기
-									md: '2rem'  // medium devices에서의 폰트 크기
-								},
-							}}
-						>
-							위인들만 기념관을 만들 수 있는 것은 아닙니다.<br/>
-							여러분 혹은 여러분이 사랑하는 사람의 기념관을 만들어보세요
-						</Typography>
-						<Stack
-							sx={{ pt: 4 }}
-							direction="row"
-							spacing={2}
-							justifyContent="center"
-						>
-							<NextLink href={redirectUrl} passHref>
-								<Button variant="contained">새로 기념관 건립</Button>
-							</NextLink>
-							<NextLink href={redirectUrl} passHref>
-								<Button variant="outlined">내가 건립한 기념관 수정</Button>
-							</NextLink>
-						</Stack>
-					</Container>
-				</Box>
-				<Box className={"main-diff-card-section"}>
-					<Container sx={{ py: 8 }} maxWidth="md">
+		<div
+			className={className}
+			style={{
+				...style,
+				display: "block",
+				right: "-25px",
+				zIndex: 1,
+				cursor: "pointer",
+				background: "none",
+				border: "none"
+			}}
+			onClick={onClick}
+		>
+			<ArrowForwardIos style={{ fontSize: '2rem', color: 'black' }} />
+		</div>
+	);
+};
+
+const PrevArrow = (props: any) => {
+	const { className, style, onClick } = props;
+	return (
+		<div
+			className={className}
+			style={{
+				...style,
+				display: "block",
+				left: "-25px",
+				zIndex: 1,
+				cursor: "pointer",
+				background: "none",
+				border: "none"
+			}}
+			onClick={onClick}
+		>
+			<ArrowBackIos style={{ fontSize: '2rem', color: 'black' }} />
+		</div>
+	);
+};
+
+export default function Main({ memorialCards }: MainProps) {
+	const { status } = useSession();
+	const redirectUrl = status === 'authenticated' ? '/form' : '/signin';
+	const theme = useTheme();
+	const isDesktop = useMediaQuery(theme.breakpoints.up('md'));
+
+	const settings = {
+		dots: false,
+		infinite: true,
+		speed: 500,
+		slidesToShow: 4,
+		slidesToScroll: 4,
+		nextArrow: <NextArrow />,
+		prevArrow: <PrevArrow />,
+		responsive: [
+			{
+				breakpoint: 1024,
+				settings: {
+					slidesToShow: 3,
+					slidesToScroll: 3,
+					infinite: true,
+					dots: false
+				}
+			},
+			{
+				breakpoint: 600,
+				settings: {
+					slidesToShow: 2,
+					slidesToScroll: 2,
+					initialSlide: 2,
+					dots: false
+				}
+			},
+			{
+				breakpoint: 480,
+				settings: {
+					slidesToShow: 1,
+					slidesToScroll: 1,
+					dots: false
+				}
+			}
+		]
+	};
+
+	return (
+		<main>
+			<style jsx global>{`
+                .slick-prev:before,
+                .slick-next:before {
+                    display: none;
+                }
+            `}</style>
+			{/* Hero unit */}
+			<Box
+				sx={{
+					bgcolor: 'background.paper',
+					pt: 8,
+					pb: 6,
+				}}
+			>
+				<Container maxWidth="md">
+					<Typography
+						component="h1"
+						align="center"
+						color="text.primary"
+						gutterBottom
+						sx={{
+							fontSize: {
+								xs: '2rem',
+								sm: '2.5rem',
+								md: '4rem'
+							},
+							fontWeight: 300
+						}}
+					>
+						기념관 만들기!
+					</Typography>
+					<Typography
+						align="center"
+						color="text.secondary"
+						paragraph
+						sx={{
+							fontSize: {
+								xs: '.9rem',
+								sm: '1.5rem',
+								md: '2rem'
+							},
+						}}
+					>
+						위인들만 기념관을 만들 수 있는 것은 아닙니다.<br />
+						여러분 혹은 여러분이 사랑하는 사람의 기념관을 만들어보세요
+					</Typography>
+					<Stack
+						sx={{ pt: 4 }}
+						direction="row"
+						spacing={2}
+						justifyContent="center"
+					>
+						<NextLink href={redirectUrl} passHref>
+							<Button variant="contained">새로 기념관 건립</Button>
+						</NextLink>
+						<NextLink href={redirectUrl} passHref>
+							<Button variant="outlined">내가 건립한 기념관 수정</Button>
+						</NextLink>
+					</Stack>
+				</Container>
+			</Box>
+			<Box className={"main-diff-card-section"}>
+				<Container sx={{ py: 8 }} maxWidth="md">
 					<Typography
 						align="center"
 						gutterBottom
@@ -89,63 +185,83 @@ export default function Main({memorialCards}: MainProps) {
 						기념관 리스트
 					</Typography>
 					{/* End hero unit */}
-					<Grid container spacing={4}>
-						{memorialCards.map((card) => (
-							<Grid item key={card.id} xs={12} sm={6} md={3}>
-								<NextLink href={`/detail/${card.id}`} passHref>
-									<Card
-										sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}
-									>
-										<CardMedia
-											component="div"
-											sx={{
-												// 16:9
-												pt: '56.25%',
-											}}
-											image={card.attachment_profile_image ? `${process.env.NEXT_PUBLIC_IMAGE}${card.attachment_profile_image.file_path}${card.attachment_profile_image.file_name}` : "https://source.unsplash.com/random?wallpapers"}
-										/>
-									</Card>
-								</NextLink>
-							</Grid>
-						))}
-					</Grid>
+					{isDesktop ? (
+						<Slider {...settings}>
+							{memorialCards.map((card) => (
+								<Box key={card.id} sx={{ px: 2 }}>
+									<NextLink href={`/detail/${card.id}`} passHref>
+										<Card
+											sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}
+										>
+											<CardMedia
+												component="div"
+												sx={{
+													pt: '75%'
+												}}
+												image={card.attachment_profile_image ? `${process.env.NEXT_PUBLIC_IMAGE}${card.attachment_profile_image.file_path}${card.attachment_profile_image.file_name}` : "https://source.unsplash.com/random?wallpapers"}
+											/>
+										</Card>
+									</NextLink>
+								</Box>
+							))}
+						</Slider>
+					) : (
+						<Grid container spacing={4}>
+							{memorialCards.map((card) => (
+								<Grid item key={card.id} xs={12} sm={6} md={3}>
+									<NextLink href={`/detail/${card.id}`} passHref>
+										<Card
+											sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}
+										>
+											<CardMedia
+												component="div"
+												sx={{
+													pt: '75%'
+												}}
+												image={card.attachment_profile_image ? `${process.env.NEXT_PUBLIC_IMAGE}${card.attachment_profile_image.file_path}${card.attachment_profile_image.file_name}` : "https://source.unsplash.com/random?wallpapers"}
+											/>
+										</Card>
+									</NextLink>
+								</Grid>
+							))}
+						</Grid>
+					)}
 				</Container>
-				</Box>
-				<Box
-					sx={{
-						bgcolor: 'background.paper',
-						pt: 8,
-						pb: 6,
-					}}
-				>
-					<Container maxWidth="md">
-						<Typography
-							align="center"
-							gutterBottom
-							sx={{
-								fontSize: {
-									xs: '1.7rem',  // extra-small devices에서의 폰트 크기
-									sm: '2.5rem', // small devices에서의 폰트 크기
-									md: '3.5rem'  // medium devices에서의 폰트 크기
-								},
-								fontWeight: 300
-							}}
-						>
-							인생 기념관 프로젝트를 시작하며
-						</Typography>
-						<Box
-							sx={{
-								display: 'flex',
-								justifyContent: 'center',
-							}}>
+			</Box>
+			<Box
+				sx={{
+					bgcolor: 'background.paper',
+					pt: 8,
+					pb: 6,
+				}}
+			>
+				<Container maxWidth="md">
+					<Typography
+						align="center"
+						gutterBottom
+						sx={{
+							fontSize: {
+								xs: '1.7rem',
+								sm: '2.5rem',
+								md: '3.5rem'
+							},
+							fontWeight: 300
+						}}
+					>
+						인생 기념관 프로젝트를 시작하며
+					</Typography>
+					<Box
+						sx={{
+							display: 'flex',
+							justifyContent: 'center',
+						}}>
 						<Card
 							sx={{ my: 4, width: '30%', display: 'flex', flexDirection: 'column' }}
 						>
 							<CardMedia
 								component="div"
 								sx={{
-									// 16:9
-									pt: '56.25%',
+									pt: '75%'
 								}}
 								image="https://source.unsplash.com/random?wallpapers"
 							/>
@@ -158,25 +274,24 @@ export default function Main({memorialCards}: MainProps) {
 								</Typography>
 							</CardContent>
 						</Card>
-						</Box>
-						<Typography
-							align="center"
-							color="text.secondary"
-							paragraph
-							sx={{
-								fontSize: {
-									xs: '.9rem',  // extra-small devices에서의 폰트 크기
-									sm: '1.5rem', // small devices에서의 폰트 크기
-									md: '2rem'  // medium devices에서의 폰트 크기
-								},
-							}}
-						>
-							위인들만 기념관을 만들 수 있는 것은 아닙니다.<br/>
-							여러분 혹은 여러분이 사랑하는 사람의 기념관을 만들어보세요
-						</Typography>
-					</Container>
-				</Box>
-			</main>
-		</>
+					</Box>
+					<Typography
+						align="center"
+						color="text.secondary"
+						paragraph
+						sx={{
+							fontSize: {
+								xs: '.9rem',
+								sm: '1.5rem',
+								md: '2rem'
+							},
+						}}
+					>
+						위인들만 기념관을 만들 수 있는 것은 아닙니다.<br />
+						여러분 혹은 여러분이 사랑하는 사람의 기념관을 만들어보세요
+					</Typography>
+				</Container>
+			</Box>
+		</main>
 	);
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@types/node": "20.5.4",
     "@types/react": "18.2.21",
     "@types/react-dom": "18.2.7",
+    "@types/react-slick": "^0.23.13",
     "dayjs": "^1.11.9",
     "eslint": "8.47.0",
     "eslint-config-next": "13.4.19",
@@ -26,7 +27,9 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-quill": "^2.0.0",
+    "react-slick": "^0.30.2",
     "sharp": "^0.32.6",
+    "slick-carousel": "^1.8.1",
     "typescript": "5.1.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -935,6 +935,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-slick@^0.23.13":
+  version "0.23.13"
+  resolved "https://registry.yarnpkg.com/@types/react-slick/-/react-slick-0.23.13.tgz#037434e73a58063047b121e08565f7185d811f36"
+  integrity sha512-bNZfDhe/L8t5OQzIyhrRhBr/61pfBcWaYJoq6UDqFtv5LMwfg4NsVDD2J8N01JqdAdxLjOt66OZEp6PX+dGs/A==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-transition-group@^4.4.6":
   version "4.4.6"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.6.tgz#18187bcda5281f8e10dfc48f0943e2fdf4f75e2e"
@@ -1262,6 +1269,11 @@ chownr@^1.1.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
+classnames@^2.2.5:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
+  integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
+
 client-only@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
@@ -1490,6 +1502,11 @@ enhanced-resolve@^5.12.0:
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
+
+enquire.js@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/enquire.js/-/enquire.js-2.1.6.tgz#3e8780c9b8b835084c3f60e166dbc3c2a3c89814"
+  integrity sha512-/KujNpO+PT63F7Hlpu4h3pE3TokKRHN26JYmQpPyjkRD/N57R7bPDNojMXdi7uveAKjYB7yQnartCxZnFWr0Xw==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -2457,6 +2474,13 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
+json2mq@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/json2mq/-/json2mq-0.2.0.tgz#b637bd3ba9eabe122c83e9720483aeb10d2c904a"
+  integrity sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==
+  dependencies:
+    string-convert "^0.2.0"
+
 json5@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
@@ -2510,6 +2534,11 @@ lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
+
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
 
 lodash.merge@^4.6.2:
   version "4.6.2"
@@ -3001,6 +3030,17 @@ react-quill@^2.0.0:
     lodash "^4.17.4"
     quill "^1.3.7"
 
+react-slick@^0.30.2:
+  version "0.30.2"
+  resolved "https://registry.yarnpkg.com/react-slick/-/react-slick-0.30.2.tgz#b28e992f9c519bb516a0af8d37e82cb59fee08ce"
+  integrity sha512-XvQJi7mRHuiU3b9irsqS9SGIgftIfdV5/tNcURTb5LdIokRA5kIIx3l4rlq2XYHfxcSntXapoRg/GxaVOM1yfg==
+  dependencies:
+    classnames "^2.2.5"
+    enquire.js "^2.1.6"
+    json2mq "^0.2.0"
+    lodash.debounce "^4.0.8"
+    resize-observer-polyfill "^1.5.0"
+
 react-transition-group@^4.4.5:
   version "4.4.5"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
@@ -3057,6 +3097,11 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
+
+resize-observer-polyfill@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
 resolve-from@^4.0.0:
   version "4.0.0"
@@ -3209,6 +3254,11 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
+slick-carousel@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/slick-carousel/-/slick-carousel-1.8.1.tgz#a4bfb29014887bb66ce528b90bd0cda262cc8f8d"
+  integrity sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==
+
 source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
@@ -3231,6 +3281,11 @@ streamx@^2.15.0:
   dependencies:
     fast-fifo "^1.1.0"
     queue-tick "^1.0.1"
+
+string-convert@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/string-convert/-/string-convert-0.2.1.tgz#6982cc3049fbb4cd85f8b24568b9d9bf39eeff97"
+  integrity sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==
 
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"


### PR DESCRIPTION
## 배경[이슈내용]
- [기념관 리스트 PC 버전에서만 슬라이드 되도록 수정합니다.](https://www.notion.so/mininc/12-08e130df082a4a3d9c266ee6f574a188)

## 작업내용
- 커곧내

## 테스트방법
- yarn dev 명령어로 로컬 서버를 실행합니다.
- PC 버전에서 메인의 기념관 리스트에 스와이프가 적용되었는지 확인합니다.