### PR TITLE
채팅 질문 리스트를 받고 답변을 통해 기념관을 설립합니다.

### DIFF
--- a/components/Main.tsx
+++ b/components/Main.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ComponentType } from 'react';
 import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
 import CardMedia from '@mui/material/CardMedia';
@@ -8,7 +8,7 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import NextLink from 'next/link';
 import { useSession } from 'next-auth/react';
-import Slider from 'react-slick';
+import SliderBase from 'react-slick';
 import { MainProps } from '@/types/main';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
@@ -17,6 +17,8 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import ArrowBackIos from '@mui/icons-material/ArrowBackIos';
 import ArrowForwardIos from '@mui/icons-material/ArrowForwardIos';
 import MainTopSlider from "@/components/MainTopSlider";
+
+const Slider = SliderBase as unknown as ComponentType<any>;
 
 const NextArrow = (props: any) => {
 	const { className, style, onClick } = props;

--- a/components/SignIn.tsx
+++ b/components/SignIn.tsx
@@ -7,51 +7,82 @@ import Grid from '@mui/material/Grid';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import Checkbox from '@mui/material/Checkbox';
 import NextLink from 'next/link';
 import { signIn, useSession } from "next-auth/react";
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 export default function SignIn() {
 	const { data: session } = useSession();
 	const router = useRouter();
 	const [isMounted, setIsMounted] = useState(false);
 
-	const fetchData = async () => {
-		if (session) {
-			try {
-				const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/memorial/view`, {
-					method: 'GET',
-					headers: {
-						'Authorization': `Bearer ${session.accessToken}`,
-					},
-				});
+	// callbackUrl 안전하게 파싱 (외부 URL 방지)
+	const safeCallbackUrl = useMemo(() => {
+		if (!router.isReady) return null;
 
-				if (response.ok) {
-					const result = await response.json();
-					if (result.result === 'success' && result.data) {
-						if (session.is_purchase_request) {
-							router.push(`/detail/${result.data.id}`);
-						} else {
-							router.push('/popup');
-						}
-						return;
+		const raw = router.query.callbackUrl;
+		const url = Array.isArray(raw) ? raw[0] : raw;
+
+		if (!url || typeof url !== 'string') return null;
+
+		try {
+			const decoded = decodeURIComponent(url);
+
+			// 상대 경로만 허용 (ex: /chat?x=1)
+			if (!decoded.startsWith('/')) return null;
+			if (decoded.startsWith('//')) return null;
+
+			return decoded;
+		} catch {
+			return null;
+		}
+	}, [router.isReady, router.query.callbackUrl]);
+
+	// 기존 로직(콜백이 없을 때만 쓰기)
+	const fetchData = async () => {
+		if (!session) return;
+
+		try {
+			const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/memorial/view`, {
+				method: 'GET',
+				headers: {
+					'Authorization': `Bearer ${session.accessToken}`,
+				},
+			});
+
+			if (response.ok) {
+				const result = await response.json();
+				if (result.result === 'success' && result.data) {
+					if ((session as any).is_purchase_request) {
+						router.replace(`/detail/${result.data.id}`);
+					} else {
+						router.replace('/popup');
 					}
+					return;
 				}
-				router.push('/form');
-			} catch (error) {
-				console.error('Error fetching data:', error);
-				router.push('/form');
 			}
+
+			router.replace('/form');
+		} catch (error) {
+			console.error('Error fetching data:', error);
+			router.replace('/form');
 		}
 	};
 
+	// 세션이 생기면: callbackUrl 있으면 그쪽으로 우선 이동, 없으면 기존 로직
 	useEffect(() => {
-		// async 함수를 호출합니다.
+		if (!router.isReady) return;
+		if (!session) return;
+
+		if (safeCallbackUrl) {
+			router.replace(safeCallbackUrl);
+			return;
+		}
+
 		fetchData();
-	}, [session, router]);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [session, router.isReady, safeCallbackUrl]);
 
 	useEffect(() => {
 		setIsMounted(true);
@@ -70,15 +101,18 @@ export default function SignIn() {
 		});
 
 		if (result?.ok) {
+			// 로그인 성공 시에도 callbackUrl 우선
+			if (safeCallbackUrl) {
+				router.replace(safeCallbackUrl);
+				return;
+			}
 			fetchData();
 		} else {
 			alert('아이디 또는 비밀번호를 다시 확인해주세요.');
 		}
 	};
 
-	if (!isMounted) {
-		return null;
-	}
+	if (!isMounted) return null;
 
 	return (
 		<Container component="main" maxWidth="xs">
@@ -96,6 +130,7 @@ export default function SignIn() {
 				<Typography component="h1" variant="h5">
 					Sign in
 				</Typography>
+
 				<Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1 }}>
 					<TextField
 						margin="normal"

--- a/components/chat/ChatInput.tsx
+++ b/components/chat/ChatInput.tsx
@@ -9,17 +9,38 @@ interface ChatInputProps {
   isComplete?: boolean;
   currentQuestion?: number;
   onFilesChange?: (files: File[]) => void;
+
+  inputMode?: 'name' | 'birth_start' | 'question' | 'profile';
+  totalQuestions?: number;
 }
 
-export default function ChatInput({ onSendMessage, disabled, isComplete, currentQuestion }: ChatInputProps) {
+export default function ChatInput({
+  onSendMessage,
+  disabled,
+  isComplete,
+  currentQuestion,
+  onFilesChange,
+  inputMode,
+  totalQuestions,
+}: ChatInputProps) {
   const [message, setMessage] = useState('');
   const [birthDate, setBirthDate] = useState(''); // Q2: 생년월일용
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const isNameQuestion = currentQuestion === 1;       // 이름
-  const isBirthQuestion = currentQuestion === 2;      // 생년월일
-  const isLastQuestion = currentQuestion === 10;      // 파일 업로드
+  const mode: NonNullable<ChatInputProps['inputMode']> =
+      inputMode ??
+      (currentQuestion === 1
+          ? 'name'
+          : currentQuestion === 2
+              ? 'birth_start'
+              : totalQuestions && currentQuestion === totalQuestions
+                  ? 'profile'
+                  : 'question');
+
+  const isNameQuestion = mode === 'name';       // 이름
+  const isBirthQuestion = mode === 'birth_start';      // 생년월일
+  const isLastQuestion = mode === 'profile';      // 파일 업로드
 
   const handleSend = () => {
     if (isLastQuestion && selectedFile) {

--- a/pages/chat.tsx
+++ b/pages/chat.tsx
@@ -287,6 +287,19 @@ export default function ChatPage() {
 
   const total = questions.length || 1;
   const currentStep = Math.min(currentQuestionIndex + 1, total);
+
+  const qLen = questions.length;
+  const inputMode: 'name' | 'birth_start' | 'question' | 'profile' =
+      qLen > 0
+          ? (currentQuestionIndex === 0
+              ? 'name'
+              : currentQuestionIndex === 1
+                  ? 'birth_start'
+                  : currentQuestionIndex === qLen - 1
+                      ? 'profile'
+                      : 'question')
+          : 'question';
+
   const progress =
       ((currentQuestionIndex + (messages.some((m) => m.isUser) ? 1 : 0)) / total) * 100;
 
@@ -366,6 +379,8 @@ export default function ChatPage() {
                   disabled={isTyping || isComplete || isLoadingQuestions || questions.length === 0}
                   isComplete={isComplete}
                   currentQuestion={currentStep}
+                  totalQuestions={total}
+                  inputMode={inputMode}
               />
             </div>
           </div>

--- a/pages/chat.tsx
+++ b/pages/chat.tsx
@@ -1,39 +1,54 @@
 'use client';
 
-import { useState, useRef, useEffect, useLayoutEffect } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState, useCallback } from 'react';
+import { useSession } from 'next-auth/react';
 import ChatMessage from '../components/chat/ChatMessage';
 import ChatInput from '../components/chat/ChatInput';
-import { fetchQuestions } from '@/lib/api/chat';
+import { fetchQuestions, submitChat } from '@/lib/api/chat';
+import { useRouter } from 'next/router';
 
-// === [ADD] 쿠키 헬퍼 & 타입 (7일 보존) ===
-const COOKIE_NAME = 'chatProgress';
-const COOKIE_TTL_DAYS = 7;
+/** SSR에선 useEffect, CSR에선 useLayoutEffect */
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+/** 겹침 방지 여유(px) */
+const EXTRA_GAP = 24;
 
-function setCookie(name: string, value: string, days: number) {
-  const d = new Date();
-  d.setTime(d.getTime() + days * 24 * 60 * 60 * 1000);
-  document.cookie = `${name}=${encodeURIComponent(value)};expires=${d.toUTCString()};path=/;SameSite=Lax`;
-}
-function getCookie(name: string) {
-  const key = name + '=';
-  const parts = document.cookie.split(';').map(v => v.trim());
-  for (const p of parts) if (p.indexOf(key) === 0) return decodeURIComponent(p.substring(key.length));
-  return null;
-}
+/** localStorage 키(쿠키 대신) */
+const STORAGE_KEY = 'chatProgressV2';
+
+/** IndexedDB: 파일 저장 */
+const FILE_DB_NAME = 'chatProfileFileDB';
+const FILE_STORE = 'files';
+const FILE_KEY = 'profile';
 
 type PersistedMessage = {
   id: string;
   text: string;
   isUser: boolean;
-  timestamp: string; // ISO 문자열
+  timestamp: string; // ISO
 };
+
+type ProfileMeta = {
+  name: string;
+  type: string;
+  size: number;
+  lastModified: number;
+};
+
 type PersistedState = {
+  version: 2;
   messages: PersistedMessage[];
   currentQuestionIndex: number;
   isComplete: boolean;
+
+  name: string;
+  birthStart: string;
+  promptAnswers: string[];
+
+  submitPending: boolean; // 로그인 후 자동 제출 트리거
+  profileMeta: ProfileMeta | null;
+
   savedAt: string;
 };
-// === [ADD END] ===
 
 interface Message {
   id: string;
@@ -42,20 +57,137 @@ interface Message {
   timestamp: Date;
 }
 
-/** SSR에선 useEffect, CSR에선 useLayoutEffect */
-const useIsomorphicLayoutEffect =
-    typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+/** ---------- IndexedDB helpers ---------- */
+let dbPromise: Promise<IDBDatabase> | null = null;
 
-/** 겹침 방지 여유(px): 환경 따라 16~32 권장 */
-const EXTRA_GAP = 24;
+function getDB(): Promise<IDBDatabase> {
+  if (dbPromise) return dbPromise;
+
+  dbPromise = new Promise((resolve, reject) => {
+    const req = indexedDB.open(FILE_DB_NAME, 1);
+
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(FILE_STORE)) {
+        db.createObjectStore(FILE_STORE);
+      }
+    };
+
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+
+  return dbPromise;
+}
+
+async function idbPutFile(file: File) {
+  const db = await getDB();
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(FILE_STORE, 'readwrite');
+    const store = tx.objectStore(FILE_STORE);
+
+    const payload = {
+      blob: file,
+      name: file.name,
+      type: file.type,
+      size: file.size,
+      lastModified: file.lastModified,
+      savedAt: Date.now(),
+    };
+
+    store.put(payload, FILE_KEY);
+
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+async function idbGetFile(): Promise<File | null> {
+  const db = await getDB();
+  return await new Promise<File | null>((resolve, reject) => {
+    const tx = db.transaction(FILE_STORE, 'readonly');
+    const store = tx.objectStore(FILE_STORE);
+    const req = store.get(FILE_KEY);
+
+    req.onsuccess = () => {
+      const v = req.result;
+      if (!v?.blob) return resolve(null);
+
+      const blob: Blob = v.blob;
+      const name: string = v.name ?? 'profile';
+      const type: string = v.type ?? blob.type ?? '';
+      const lastModified: number = v.lastModified ?? Date.now();
+
+      resolve(new File([blob], name, { type, lastModified }));
+    };
+
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function idbDeleteFile() {
+  const db = await getDB();
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(FILE_STORE, 'readwrite');
+    const store = tx.objectStore(FILE_STORE);
+    store.delete(FILE_KEY);
+
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+/** ---------- localStorage helpers ---------- */
+function loadPersisted(): PersistedState | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as PersistedState;
+    if (!parsed || parsed.version !== 2) return null;
+    if (!Array.isArray(parsed.messages)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function savePersisted(state: PersistedState) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // 용량/차단 등 무시
+  }
+}
+
+function clearPersisted() {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {}
+}
 
 export default function ChatPage() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [questions, setQuestions] = useState<string[]>([]);
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
+
   const [isComplete, setIsComplete] = useState(false);
   const [isTyping, setIsTyping] = useState(false);
   const [isLoadingQuestions, setIsLoadingQuestions] = useState(true);
+
+  const [name, setName] = useState('');
+  const [birthStart, setBirthStart] = useState('');
+  const [promptAnswers, setPromptAnswers] = useState<string[]>([]);
+  const [profileFile, setProfileFile] = useState<File | null>(null);
+  const [profileMeta, setProfileMeta] = useState<ProfileMeta | null>(null);
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitPending, setSubmitPending] = useState(false);
+
+  const { data: session, status } = useSession();
+  const accessToken = (session as any)?.accessToken as string | undefined;
+
+  // router
+  const router = useRouter();
 
   // 스크롤 컨테이너 & 앵커
   const messagesWrapRef = useRef<HTMLDivElement | null>(null);
@@ -68,19 +200,23 @@ export default function ChatPage() {
   // 직전 오프셋 기록(푸터 높이 급증 감지용)
   const lastFooterOffsetRef = useRef(0);
 
-  // [ADD] 쿠키 복원 1회만 수행
+  // 복원 1회만 수행
   const restoredRef = useRef(false);
+  const hasPersistedRef = useRef<boolean | null>(null);
 
-  // [ADD] 쿠키가 "있다"는 사실만 먼저 기록해서 첫질문 이펙트를 선제 차단
-  const hasCookieRef = useRef(false);  // ★ 추가
+  const showLoginRequired = submitPending && status !== 'authenticated';
 
-  // 현재 푸터 오프셋(높이 + 여유) 계산
+  // 기념관 여부 체크
+  const checkedMemorialRef = useRef(false);
+  const [isCheckingMemorial, setIsCheckingMemorial] = useState(false);
+
+  // 현재 푸터 오프셋(높이 + 여유)
   const getFooterOffset = () => {
     const h = footerInnerRef.current?.getBoundingClientRect().height ?? 0;
     return h + EXTRA_GAP;
   };
 
-  // 푸터 높이 추적 (파일 선택/미리보기/키보드 변동 반영)
+  // 푸터 높이 추적
   useEffect(() => {
     const update = () => {
       const h = footerInnerRef.current?.getBoundingClientRect().height ?? 0;
@@ -108,6 +244,55 @@ export default function ChatPage() {
     };
   }, []);
 
+  // 로그인 상태면 "이미 기념관 존재" 먼저 체크 → 있으면 홈으로
+  useEffect(() => {
+    if (!router.isReady) return;
+    if (status !== 'authenticated') return;
+    if (!accessToken) return;
+    if (checkedMemorialRef.current) return;
+
+    checkedMemorialRef.current = true;
+
+    (async () => {
+      try {
+        setIsCheckingMemorial(true);
+
+        const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/memorial/view`, {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        });
+
+        if (response.ok) {
+          const result = await response.json();
+
+          // 이미 기념관이 있으면 /chat 막고 홈으로
+          if (result?.result === 'success' && result?.data) {
+            // 진행/파일/대기 상태 정리(재진입시 자동제출 방지)
+            setSubmitPending(false);
+            setIsSubmitting(false);
+            setIsTyping(false);
+            setProfileFile(null);
+            setProfileMeta(null);
+            clearPersisted();
+            try {
+              await idbDeleteFile();
+            } catch {}
+
+            router.replace('/');
+            return;
+          }
+        }
+      } catch (e) {
+        // 체크 실패면 /chat 계속 진행
+        console.error('[chat] memorial view check failed', e);
+      } finally {
+        setIsCheckingMemorial(false);
+      }
+    })();
+  }, [router.isReady, status, accessToken, router]);
+
   // 질문 불러오기
   useEffect(() => {
     let mounted = true;
@@ -121,50 +306,63 @@ export default function ChatPage() {
         if (mounted) setIsLoadingQuestions(false);
       }
     })();
-    return () => { mounted = false; };
+    return () => {
+      mounted = false;
+    };
   }, []);
 
-  // === [ADD] 쿠키 복원 ===
-// 질문 로딩이 끝난 후(isLoadingQuestions=false)에 쿠키가 있으면 기존 대화를 복원한다.
+  // 진행 복원 (questions 로딩 후)
   useEffect(() => {
     if (restoredRef.current) return;
     if (isLoadingQuestions) return;
 
-    const raw = typeof window !== 'undefined' ? getCookie(COOKIE_NAME) : null;
-    if (!raw) return;
+    const persisted = loadPersisted();
+    hasPersistedRef.current = !!persisted;
 
-    hasCookieRef.current = true; // ★ 추가: 쿠키가 있다는 사실을 즉시 알림(파싱 전)
+    if (!persisted) return;
 
     try {
-      const parsed: PersistedState = JSON.parse(raw);
-      if (!Array.isArray(parsed.messages)) return;
-
-      const restoredMessages = parsed.messages.map((m) => ({
+      const restoredMessages = persisted.messages.map((m) => ({
         id: m.id,
         text: m.text,
         isUser: m.isUser,
         timestamp: new Date(m.timestamp),
       })) as Message[];
 
-      restoredRef.current = true;   // 먼저 true
+      restoredRef.current = true;
       setMessages(restoredMessages);
 
-      const qLen = Array.isArray(questions) ? questions.length : 0;
-      const safeIndex = Math.max(0, Math.min(parsed.currentQuestionIndex ?? 0, Math.max(0, qLen - 1)));
+      const qLen = questions.length;
+      const safeIndex = Math.max(
+          0,
+          Math.min(persisted.currentQuestionIndex ?? 0, Math.max(0, qLen - 1))
+      );
       setCurrentQuestionIndex(safeIndex);
-      setIsComplete(!!parsed.isComplete);
-    } catch (e) {
-      // 파싱 실패면 첫 질문 로직이 동작하도록 다시 허용
-      hasCookieRef.current = false; // ★ 추가: 실패 시 해제
-      console.error('[chat] cookie parse failed. length=', raw?.length, e);
+
+      setIsComplete(!!persisted.isComplete);
+      setName(persisted.name ?? '');
+      setBirthStart(persisted.birthStart ?? '');
+      setPromptAnswers(Array.isArray(persisted.promptAnswers) ? persisted.promptAnswers : []);
+      setSubmitPending(!!persisted.submitPending);
+      setProfileMeta(persisted.profileMeta ?? null);
+
+      // 파일 복원(IndexedDB)
+      if (persisted.profileMeta) {
+        void idbGetFile()
+            .then((f) => {
+              if (f) setProfileFile(f);
+            })
+            .catch(() => {});
+      }
+    } catch {
+      hasPersistedRef.current = false;
     }
-  }, [isLoadingQuestions, questions]);
+  }, [isLoadingQuestions, questions.length]);
 
-
-  // 첫 질문 표시
+  // 첫 질문 표시(저장 복원 없을 때만)
   useEffect(() => {
     if (restoredRef.current) return;
-    if (hasCookieRef.current) return; // ★ 추가: 쿠키가 '존재'하면 복원 시도 끝날 때까지 대기
+    if (hasPersistedRef.current === true) return;
     if (!isLoadingQuestions && questions.length > 0 && messages.length === 0) {
       const firstQuestion: Message = {
         id: '1',
@@ -175,14 +373,14 @@ export default function ChatPage() {
       setMessages([firstQuestion]);
       setCurrentQuestionIndex(0);
     }
-  }, [isLoadingQuestions, questions, messages.length]);
+  }, [isLoadingQuestions, questions.length, messages.length]);
 
-  // === [ADD] 진행상태 저장 (쿠키 7일) ===
+  // 진행 저장(localStorage)
   useEffect(() => {
-    // 완전 초기상태는 저장 스킵(원하면 제거 가능)
-    if (messages.length === 0 && currentQuestionIndex === 0 && !isComplete) return;
+    if (isLoadingQuestions) return;
 
     const payload: PersistedState = {
+      version: 2,
       messages: messages.map((m) => ({
         id: m.id,
         text: m.text,
@@ -191,18 +389,28 @@ export default function ChatPage() {
       })),
       currentQuestionIndex,
       isComplete,
+      name,
+      birthStart,
+      promptAnswers,
+      submitPending,
+      profileMeta,
       savedAt: new Date().toISOString(),
     };
 
-    try {
-      setCookie(COOKIE_NAME, JSON.stringify(payload), COOKIE_TTL_DAYS);
-    } catch {
-      // 쿠키 용량/브라우저 제한 등으로 실패하면 조용히 무시
-    }
-  }, [messages, currentQuestionIndex, isComplete]);
+    savePersisted(payload);
+  }, [
+    isLoadingQuestions,
+    messages,
+    currentQuestionIndex,
+    isComplete,
+    name,
+    birthStart,
+    promptAnswers,
+    submitPending,
+    profileMeta,
+  ]);
 
-
-  // 정확한 바닥 스크롤 (푸터 커질 때 rAF 지연 가변)
+  // 스크롤
   const scrollToBottomSmooth = () => {
     const el = messagesWrapRef.current;
     if (!el) return;
@@ -211,22 +419,14 @@ export default function ChatPage() {
     const prevOffset = lastFooterOffsetRef.current;
     lastFooterOffsetRef.current = currentOffset;
 
-    // 푸터가 방금 커졌다면 프레임 여유를 더 줌(파일 미리보기/키보드 등장 흡수)
     const delayFrames = currentOffset > prevOffset + 6 ? 3 : 2;
 
     const doScroll = () => {
       const bottom = Math.max(0, el.scrollHeight - el.clientHeight);
-      if ('scrollTo' in el) {
-        el.scrollTo({ top: bottom, behavior: 'smooth' });
-      } else {
-        // TS 안전상황이지만 폴백 유지
-        (el as HTMLDivElement).scrollTop = bottom;
-      }
-      // 브라우저별 소폭 오차 보정
+      el.scrollTo?.({ top: bottom, behavior: 'smooth' });
       messagesEndRef.current?.scrollIntoView({ block: 'end' });
     };
 
-    // delayFrames 만큼 rAF 체인
     let i = 0;
     const tick = () => {
       if (++i >= delayFrames) doScroll();
@@ -235,16 +435,116 @@ export default function ChatPage() {
     requestAnimationFrame(tick);
   };
 
-  // 메시지/푸터 높이 변화 시, 렌더 직후 스크롤 보장
   useIsomorphicLayoutEffect(() => {
-    if (messages.length > 0) {
+    if (messages.length > 0) scrollToBottomSmooth();
+  }, [messages.length, footerHeight]);
+
+  // 파일 선택 변경
+  const handleFilesChange = async (files: File[]) => {
+    const f = files[0] ?? null;
+    setProfileFile(f);
+
+    if (!f) {
+      setProfileMeta(null);
+      try {
+        await idbDeleteFile();
+      } catch {}
+      return;
+    }
+
+    setProfileMeta({
+      name: f.name,
+      type: f.type,
+      size: f.size,
+      lastModified: f.lastModified,
+    });
+
+    try {
+      await idbPutFile(f);
+    } catch {}
+  };
+
+  const pushBot = (text: string) => {
+    const botMessage: Message = {
+      id: (Date.now() + 1).toString(),
+      text,
+      isUser: false,
+      timestamp: new Date(),
+    };
+    setMessages((prev) => [...prev, botMessage]);
+  };
+
+  const doSubmit = useCallback(async () => {
+    if (isSubmitting || isComplete) return;
+    if (isCheckingMemorial) return; // 체크 중 제출 금지
+
+    if (!profileFile) {
+      pushBot('파일이 선택되지 않았습니다. 파일을 선택한 뒤 다시 시도해주세요.');
+      return;
+    }
+
+    if (!accessToken) {
+      setSubmitPending(true);
+      pushBot('로그인이 필요합니다. 로그인 후 자동으로 제출됩니다.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setIsTyping(true);
+
+    try {
+      const prompts = (promptAnswers ?? []).join('\n\n');
+
+      await submitChat({
+        accessToken,
+        name,
+        birth_start: birthStart,
+        prompts,
+        profile: profileFile,
+      });
+
+      pushBot('제출이 완료되었습니다. 소중한 이야기를 들려주셔서 감사합니다. 여러분의 기억과 추억이 안전하게 보관되었습니다.');
+      setIsComplete(true);
+      setSubmitPending(false);
+
+      setProfileFile(null);
+      setProfileMeta(null);
+      try {
+        await idbDeleteFile();
+      } catch {}
+    } catch (err: any) {
+      const msg = err?.message ?? 'unknown error';
+      pushBot(`제출에 실패했습니다. 다시 시도해주세요.\n(${msg})`);
+
+      if (String(msg).includes('401')) {
+        setSubmitPending(true);
+      }
+    } finally {
+      setIsSubmitting(false);
+      setIsTyping(false);
       scrollToBottomSmooth();
     }
-  }, [messages.length, footerHeight]);
+  }, [isSubmitting, isComplete, isCheckingMemorial, profileFile, accessToken, promptAnswers, name, birthStart]);
+
+  // 로그인 후 자동 제출
+  useEffect(() => {
+    if (isCheckingMemorial) return; // 체크 중엔 자동 제출 금지
+    if (!submitPending) return;
+    if (status !== 'authenticated') return;
+    if (isComplete) return;
+    if (!profileFile) return;
+
+    void doSubmit();
+  }, [isCheckingMemorial, submitPending, status, isComplete, profileFile, doSubmit]);
 
   // 메시지 전송 핸들러
   const handleSendMessage = async (text: string) => {
+    if (isCheckingMemorial) return; // 체크 중 입력 무시
     if (isComplete || questions.length === 0) return;
+    if (isSubmitting) return;
+
+    const qLen = questions.length;
+    const isProfileStep = currentQuestionIndex === qLen - 1;
 
     const userMessage: Message = {
       id: Date.now().toString(),
@@ -253,33 +553,42 @@ export default function ChatPage() {
       timestamp: new Date(),
     };
     setMessages((prev) => [...prev, userMessage]);
-    setIsTyping(true);
 
+    if (!isProfileStep) {
+      if (currentQuestionIndex === 0) setName(text);
+      else if (currentQuestionIndex === 1) setBirthStart(text);
+      else setPromptAnswers((prev) => [...prev, text]);
+    }
+
+    if (isProfileStep) {
+      if (!accessToken) {
+        setSubmitPending(true);
+        pushBot('로그인이 필요합니다. 로그인 후 자동으로 제출됩니다.');
+        return;
+      }
+
+      await doSubmit();
+      return;
+    }
+
+    setIsTyping(true);
     setTimeout(() => {
       const nextIndex = currentQuestionIndex + 1;
-      let botMessage: Message;
 
       if (nextIndex < questions.length) {
-        botMessage = {
+        const botMessage: Message = {
           id: (Date.now() + 1).toString(),
           text: questions[nextIndex],
           isUser: false,
           timestamp: new Date(),
         };
         setCurrentQuestionIndex(nextIndex);
+        setMessages((prev) => [...prev, botMessage]);
       } else {
-        botMessage = {
-          id: (Date.now() + 1).toString(),
-          text:
-              '모든 질문이 완료되었습니다. 소중한 이야기를 들려주셔서 감사합니다. 여러분의 기억과 추억이 안전하게 보관되었습니다.',
-          isUser: false,
-          timestamp: new Date(),
-        };
+        pushBot('모든 질문이 완료되었습니다. 소중한 이야기를 들려주셔서 감사합니다.');
         setIsComplete(true);
       }
 
-      setMessages((prev) => [...prev, botMessage]);
-      // 즉시 한 번, 그리고 위 useIsomorphicLayoutEffect에서 렌더 후 한 번 더
       scrollToBottomSmooth();
       setIsTyping(false);
     }, 800);
@@ -288,16 +597,15 @@ export default function ChatPage() {
   const total = questions.length || 1;
   const currentStep = Math.min(currentQuestionIndex + 1, total);
 
-  const qLen = questions.length;
   const inputMode: 'name' | 'birth_start' | 'question' | 'profile' =
-      qLen > 0
-          ? (currentQuestionIndex === 0
+      questions.length > 0
+          ? currentQuestionIndex === 0
               ? 'name'
               : currentQuestionIndex === 1
                   ? 'birth_start'
-                  : currentQuestionIndex === qLen - 1
+                  : currentQuestionIndex === questions.length - 1
                       ? 'profile'
-                      : 'question')
+                      : 'question'
           : 'question';
 
   const progress =
@@ -305,8 +613,36 @@ export default function ChatPage() {
 
   const footerOffsetNow = getFooterOffset();
 
+  const loginHref =
+      typeof window !== 'undefined'
+          ? `/signin?callbackUrl=${encodeURIComponent(window.location.pathname + window.location.search)}`
+          : '/signin';
+
+  // 체크 중이면 오버레이 (질문 로딩/자동제출/입력보다 우선)
+  const shouldBlockUI = isCheckingMemorial;
+
   return (
       <div className="min-h-svh bg-gray-50 flex flex-col min-h-0">
+        {/* 기념관 체크 오버레이 */}
+        {shouldBlockUI && (
+            <div className="fixed inset-0 z-[70] bg-black/30 flex items-center justify-center">
+              <div className="bg-white rounded-2xl px-6 py-5 shadow-lg">
+                <div className="w-8 h-8 border-2 border-black border-t-transparent rounded-full animate-spin mx-auto" />
+                <p className="mt-3 text-sm text-gray-700 text-center">확인 중...</p>
+              </div>
+            </div>
+        )}
+
+        {/* 제출 중 오버레이 스피너 */}
+        {isSubmitting && (
+            <div className="fixed inset-0 z-[60] bg-black/30 flex items-center justify-center">
+              <div className="bg-white rounded-2xl px-6 py-5 shadow-lg">
+                <div className="w-8 h-8 border-2 border-black border-t-transparent rounded-full animate-spin mx-auto" />
+                <p className="mt-3 text-sm text-gray-700 text-center">제출 중...</p>
+              </div>
+            </div>
+        )}
+
         <div className="flex-1 flex flex-col max-w-4xl mx-auto w-full my-0 md:my-4 px-0 md:px-4 min-h-0">
           {/* 진행률 */}
           <div className="bg-white border-0 md:border border-gray-200 rounded-none md:rounded-t-xl px-4 py-3 flex-shrink-0">
@@ -314,6 +650,7 @@ export default function ChatPage() {
             <span className="text-sm text-gray-600">
               {isLoadingQuestions ? '질문 로딩중…' : `질문 ${currentStep} / ${total}`}
             </span>
+
               <div className="flex-1 mx-4">
                 <div className="w-full bg-gray-200 rounded-full h-2">
                   <div
@@ -322,13 +659,14 @@ export default function ChatPage() {
                   />
                 </div>
               </div>
+
               <span className="text-sm text-gray-600">
               {isComplete ? '완료' : isLoadingQuestions ? '로딩중' : '진행중'}
             </span>
             </div>
           </div>
 
-          {/* 대화 영역: 패딩/scrollPadding + 앵커 margin + 실제 스페이서로 겹침 방지 */}
+          {/* 대화 영역 */}
           <div
               ref={messagesWrapRef}
               className="flex-1 overflow-y-auto px-4 md:px-6 py-4 md:py-6 bg-white border-0 md:border-l md:border-r border-gray-200 min-h-0"
@@ -345,38 +683,29 @@ export default function ChatPage() {
               <div ref={messagesEndRef} style={{ scrollMarginBottom: footerOffsetNow }} />
             </div>
 
-            {/* 실제 여백: fixed 인풋 높이 + 여유 */}
             <div style={{ height: footerOffsetNow }} />
           </div>
         </div>
 
         {/* 고정 입력창 푸터 */}
-        <div
-            className="
-          fixed bottom-0 inset-x-0 z-50
-          bg-transparent border-0
-          pb-[env(safe-area-inset-bottom)]
-          pointer-events-none
-        "
-        >
-          <div
-              ref={footerInnerRef}
-              className="
-            max-w-4xl mx-auto w-full px-0 md:px-4
-            pointer-events-auto
-          "
-          >
-            <div
-                className="
-              bg-white
-              border-t border-gray-200
-              md:border md:border-gray-200
-              rounded-none md:rounded-b-xl
-            "
-            >
+        <div className="fixed bottom-0 inset-x-0 z-50 bg-transparent border-0 pb-[env(safe-area-inset-bottom)] pointer-events-none">
+          <div ref={footerInnerRef} className="max-w-4xl mx-auto w-full px-0 md:px-4 pointer-events-auto">
+            <div className="bg-white border-t border-gray-200 md:border md:border-gray-200 rounded-none md:rounded-b-xl">
               <ChatInput
                   onSendMessage={handleSendMessage}
-                  disabled={isTyping || isComplete || isLoadingQuestions || questions.length === 0}
+                  onFilesChange={handleFilesChange}
+                  selectedFile={profileFile}
+                  isSubmitting={isSubmitting}
+                  showLoginRequired={showLoginRequired}
+                  loginHref={loginHref}
+                  disabled={
+                      shouldBlockUI ||
+                      isTyping ||
+                      isSubmitting ||
+                      isComplete ||
+                      isLoadingQuestions ||
+                      questions.length === 0
+                  }
                   isComplete={isComplete}
                   currentQuestion={currentStep}
                   totalQuestions={total}


### PR DESCRIPTION
## 배경[이슈내용]
- 채팅을 통해 기념관 설립이 쉬워집니다.
- 회원가입부터가 아닌 기념관 설립부터 진행하여 이탈률을 줄일 수 있습니다.

## 작업내용
- 채팅 질문 리스트를 API로 받습니다.
- 답변을 입력하고 파일 업로드 완료 시 기념관 설립 API를 호출합니다.
- 답변 입력 후 페이지 이탈 시 localStorage 에 저장하여 데이터를 불러올 수 있습니다.
- 기념관이 있는 고객이 채팅 페이지 접근 시 홈으로 리다이렉트 됩니다.

## 테스트방법
- git pull 후 yarn dev 명령어로 로컬 서버를 실행합니다.
- /intro 페이지에 진입합니다.
- '내 인생 기념관 만들기' 버튼을 누르거나 /chat 페이지로 직접 url 진입합니다.
- 채팅 UI 형식의 질문/답변을 받을 수 있는지 확인합니다.
- 답변 작성 도중 페이지 이탈 후 다시 채팅 페이지로 접근 시 입력했던 답변들이 나오는지 확인합니다.
- '파일 업로드 완료' 버튼 클릭 시 로그인 되어 있지 않은 경우 로그인 페이지로 이동하는지 확인합니다.
- 로그인 후 자동으로 채팅의 답변이 '제출' 되는지 확인합니다.
- 정상적으로 기념관이 설립되는지 확인합니다.
