### PR TITLE
chat 으로 기념관 설립 후 기념관으로 이동되도록 합니다

### DIFF
--- a/pages/chat.tsx
+++ b/pages/chat.tsx
@@ -216,6 +216,14 @@ export default function ChatPage() {
     return h + EXTRA_GAP;
   };
 
+  const redirectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (redirectTimerRef.current) clearTimeout(redirectTimerRef.current);
+    };
+  }, []);
+
   // 푸터 높이 추적
   useEffect(() => {
     const update = () => {
@@ -495,7 +503,7 @@ export default function ChatPage() {
     try {
       const prompts = (promptAnswers ?? []).join('\n\n');
 
-      await submitChat({
+      const result = await submitChat({
         accessToken,
         name,
         birth_start: birthStart,
@@ -512,6 +520,15 @@ export default function ChatPage() {
       try {
         await idbDeleteFile();
       } catch {}
+
+      clearPersisted();
+
+      const memorialId = result?.data?.id;
+
+      if (redirectTimerRef.current) clearTimeout(redirectTimerRef.current);
+      redirectTimerRef.current = setTimeout(() => {
+        router.replace(`/detail/${memorialId}`);
+      }, 1000);
     } catch (err: any) {
       const msg = err?.message ?? 'unknown error';
       pushBot(`제출에 실패했습니다. 다시 시도해주세요.\n(${msg})`);


### PR DESCRIPTION
## 배경[이슈내용]
- chat으로 기념관을 설립합니다.
- chat form 제출 후 생성된 기념관으로 이동됩니다.

## 작업내용
- 기념관 생성 후 설립된 기념관으로 자동 이동됩니다.

## 테스트방법
- git pull 후 yarn dev 명령어로 로컬 서버를 실행합니다.
- /intro 페이지에 진입합니다.
- '내 인생 기념관 만들기' 버튼을 누르거나 /chat 페이지로 직접 url 진입합니다.
- 정상적으로 기념관이 설립되는지 확인합니다.
-  기념관 설립 후 기념관으로 자동으로 이동되는지 확인합니다.
