### PR TITLE
local storage 에 저장된 채팅 답변을 초기화 할 수 있도록 수정합니다

### DIFF
--- a/firebase.ts
+++ b/firebase.ts
@@ -1,18 +1,28 @@
 // firebase.ts
-import { initializeApp, FirebaseApp } from "firebase/app";
-import { getAnalytics, Analytics } from "firebase/analytics";
+import { initializeApp, getApps, getApp } from "firebase/app";
+import type { FirebaseApp } from "firebase/app";
+import type { Analytics } from "firebase/analytics";
 
 const firebaseConfig = {
-    apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
-    authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
-    projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
-    storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
-    messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
-    appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
-    measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
+    apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY!,
+    authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN!,
+    projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID!, // <- 이게 비면 터짐
+    storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET!,
+    messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID!,
+    appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID!,
+    measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID!,
 };
 
-const app: FirebaseApp = initializeApp(firebaseConfig);
-const analytics: Analytics | null = typeof window !== "undefined" ? getAnalytics(app) : null;
+export const app: FirebaseApp = getApps().length ? getApp() : initializeApp(firebaseConfig);
 
-export { analytics };
+export async function getAnalyticsInstance(): Promise<Analytics | null> {
+    if (process.env.NEXT_PUBLIC_APP_ENV_VALUE !== "production") return null;
+    if (typeof window === "undefined") return null;
+
+    if (!firebaseConfig.projectId) return null;
+
+    const { isSupported, getAnalytics } = await import("firebase/analytics");
+    if (!(await isSupported())) return null;
+
+    return getAnalytics(app);
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,28 +8,32 @@ import Footer from '../components/common/Footer';
 import Header from '../components/common/Header';
 import { SessionProvider } from 'next-auth/react';
 import { useRouter } from 'next/router';
-import { analytics } from '@/firebase';
 import { logEvent } from 'firebase/analytics';
 
 export default function App({ Component, pageProps }: AppProps) {
   const router = useRouter();
 
   useEffect(() => {
-    if (typeof window !== 'undefined' && process.env.APP_ENV_VALUE !== 'local') {
+    if (process.env.NEXT_PUBLIC_APP_ENV_VALUE !== "production") return;
+
+    let detach = () => {};
+
+    (async () => {
+      const { getAnalyticsInstance } = await import("@/firebase");
+      const analytics = await getAnalyticsInstance();
+      if (!analytics) return;
+
       const handleRouteChange = (url: string) => {
-        if (analytics) {
-          logEvent(analytics, 'page_view', {
-            page_path: url,
-          });
-        }
+        logEvent(analytics, "page_view", { page_path: url });
       };
 
-      router.events.on('routeChangeComplete', handleRouteChange);
+      router.events.on("routeChangeComplete", handleRouteChange);
       handleRouteChange(window.location.pathname);
-      return () => {
-        router.events.off('routeChangeComplete', handleRouteChange);
-      };
-    }
+
+      detach = () => router.events.off("routeChangeComplete", handleRouteChange);
+    })();
+
+    return () => detach();
   }, [router.events]);
 
   const theme = makeTheme('light');

--- a/pages/chat.tsx
+++ b/pages/chat.tsx
@@ -224,6 +224,70 @@ export default function ChatPage() {
     };
   }, []);
 
+  // reset
+  const [resetNonce, setResetNonce] = useState(0);
+  const resetProgress = useCallback(async () => {
+    // 제출중/체크중엔 초기화 막기
+    if (isSubmitting || isCheckingMemorial) return;
+
+    if (typeof window !== 'undefined') {
+      const ok = window.confirm('저장된 진행 내용을 모두 초기화할까요?');
+      if (!ok) return;
+    }
+
+    // 예약된 리다이렉트가 있으면 취소
+    if (redirectTimerRef.current) {
+      clearTimeout(redirectTimerRef.current);
+      redirectTimerRef.current = null;
+    }
+
+    // 저장 데이터 삭제
+    clearPersisted();
+    try {
+      await idbDeleteFile();
+    } catch {}
+
+    // ref 플래그 리셋 (복원 로직이 다시 "없음"으로 동작하게)
+    restoredRef.current = false;
+    hasPersistedRef.current = false;
+
+    // 상태 리셋
+    setSubmitPending(false);
+    setIsSubmitting(false);
+    setIsTyping(false);
+    setIsComplete(false);
+
+    setName('');
+    setBirthStart('');
+    setPromptAnswers([]);
+
+    setProfileFile(null);
+    setProfileMeta(null);
+
+    setCurrentQuestionIndex(0);
+
+    // 첫 질문 다시 세팅(질문 로딩 완료된 경우)
+    if (!isLoadingQuestions && questions.length > 0) {
+      const firstQuestion: Message = {
+        id: '1',
+        text: questions[0],
+        isUser: false,
+        timestamp: new Date(),
+      };
+      setMessages([firstQuestion]);
+    } else {
+      setMessages([]);
+    }
+
+    setResetNonce((n) => n + 1);
+
+    // 스크롤 맨 위로
+    requestAnimationFrame(() => {
+      messagesWrapRef.current?.scrollTo?.({ top: 0 });
+    });
+  }, [isSubmitting, isCheckingMemorial, isLoadingQuestions, questions]);
+  // reset end
+
   // 푸터 높이 추적
   useEffect(() => {
     const update = () => {
@@ -677,9 +741,20 @@ export default function ChatPage() {
                 </div>
               </div>
 
-              <span className="text-sm text-gray-600">
-              {isComplete ? '완료' : isLoadingQuestions ? '로딩중' : '진행중'}
-            </span>
+              <div className="flex items-center gap-3">
+                <span className="text-sm text-gray-600">
+                  {isComplete ? '완료' : isLoadingQuestions ? '로딩중' : '진행중'}
+                </span>
+
+                <button
+                    type="button"
+                    onClick={resetProgress}
+                    disabled={shouldBlockUI || isSubmitting}
+                    className="text-xs text-gray-500 hover:text-gray-900 underline disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  초기화
+                </button>
+              </div>
             </div>
           </div>
 
@@ -709,6 +784,7 @@ export default function ChatPage() {
           <div ref={footerInnerRef} className="max-w-4xl mx-auto w-full px-0 md:px-4 pointer-events-auto">
             <div className="bg-white border-t border-gray-200 md:border md:border-gray-200 rounded-none md:rounded-b-xl">
               <ChatInput
+                  key={resetNonce}
                   onSendMessage={handleSendMessage}
                   onFilesChange={handleFilesChange}
                   selectedFile={profileFile}


### PR DESCRIPTION
## 배경[이슈내용]
- local storage 에 저장된 채팅 답변을 초기화할 수 있어야 합니다.

## 작업내용
- 채팅 상단 진행바 옆에 초기화 버튼을 생성합니다.
- 초기화 버튼 클릭 시 저장된 답변 내용이 초기화 됩니다.

## 테스트방법
- git pull 후 yarn dev 명령어로 로컬 서버를 실행합니다.
- /intro 페이지에 진입합니다.
- '내 인생 기념관 만들기' 버튼을 누르거나 /chat 페이지로 직접 url 진입합니다.
- 채팅 질문에 답변을 합니다.
- 초기화 버튼을 눌러 답변 내용이 사라지는지 확인합니다.
