### PR TITLE
채팅 완료 후 회원가입 > 로그인 시 채팅 form 을 제출하도록 수정합니다

### DIFF
--- a/components/SignIn.tsx
+++ b/components/SignIn.tsx
@@ -173,7 +173,14 @@ export default function SignIn() {
 							</Typography>
 						</Grid>
 						<Grid item>
-							<MUILink component={NextLink} href="/signup">
+							<MUILink
+								component={NextLink}
+								href={
+									safeCallbackUrl
+										? { pathname: '/signup', query: { callbackUrl: safeCallbackUrl } }
+										: '/signup'
+								}
+							>
 								회원가입
 							</MUILink>
 						</Grid>

--- a/components/SignUp.tsx
+++ b/components/SignUp.tsx
@@ -9,7 +9,7 @@ import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import NextLink from 'next/link';
 import { useRouter } from 'next/router';
-import {useState} from "react";
+import {useState, useMemo} from "react";
 
 function Copyright() {
 	return (
@@ -27,6 +27,22 @@ function Copyright() {
 export default function SignUp() {
 	const router = useRouter();
 	const [isDisabled, setDisabled] = useState(false);
+	const safeCallbackUrl = useMemo(() => {
+		if (!router.isReady) return null;
+
+		const raw = router.query.callbackUrl;
+		const url = Array.isArray(raw) ? raw[0] : raw;
+		if (!url || typeof url !== 'string') return null;
+
+		try {
+			const decoded = decodeURIComponent(url);
+			if (!decoded.startsWith('/')) return null;
+			if (decoded.startsWith('//')) return null;
+			return decoded;
+		} catch {
+			return null;
+		}
+	}, [router.isReady, router.query.callbackUrl]);
 	const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
 		setDisabled(true);
@@ -61,7 +77,11 @@ export default function SignUp() {
 				});
 
 				if (response.ok) {
-					router.push('/signin');
+					router.push(
+						safeCallbackUrl
+							? `/signin?callbackUrl=${encodeURIComponent(safeCallbackUrl)}`
+							: '/signin'
+					);
 				} else {
 					const result = await response.json();
 					alert('회원 가입 실패: ' + result.error[0]);
@@ -163,7 +183,14 @@ export default function SignUp() {
 						</Button>
 						<Grid container justifyContent="flex-end">
 							<Grid item>
-								<NextLink href="/signin" passHref>
+								<NextLink
+									href={
+										safeCallbackUrl
+											? { pathname: '/signin', query: { callbackUrl: safeCallbackUrl } }
+											: '/signin'
+									}
+									passHref
+								>
 									<MUILink variant="body2" component={"button"}>
 										이미 회원 이신가요?
 									</MUILink>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -5,28 +5,28 @@
 
 @font-face {
   font-family: 'Grandiflora One';
-  src: url('../public/fonts/GrandifloraOne-Regular.ttf') format('truetype');
+  src: url('/fonts/GrandifloraOne-Regular.ttf') format('truetype');
   font-style: normal;
   font-weight: 400;
 }
 
 @font-face {
   font-family: 'GowunDodum';
-  src: url('../public/fonts/GowunDodum-Regular.ttf') format('truetype');
+  src: url('/fonts/GowunDodum-Regular.ttf') format('truetype');
   font-style: normal;
   font-weight: 400;
 }
 
 @font-face {
   font-family: 'Noto Sans';
-  src: url('../public/fonts/NotoSans-Regular.ttf') format('truetype');
+  src: url('/fonts/NotoSans-Regular.ttf') format('truetype');
   font-style: normal;
   font-weight: 400;
 }
 
 @font-face {
   font-family: 'Inter';
-  src: url('../public/fonts/Inter_18pt-Regular.ttf') format('truetype');
+  src: url('/fonts/Inter_18pt-Regular.ttf') format('truetype');
   font-style: normal;
   font-weight: 400;
 }


### PR DESCRIPTION
## 배경[이슈내용]
- 로그아웃된 상태에서 채팅 답변 완료 후 회원가입 > 로그인을 하게되면 api 를 호출하지 않는 오류를 수정합니다.

## 작업내용
- 로그인 페이지에서 회원가입 페이지로 이동할 때 callbackUrl 을 붙여서 보냅니다.
- 회원가입 페이지에서 회원가입 완료 후 로그인 페이지로 이동할 때 callbackUrl 을 붙여서 보냅니다.

## 테스트방법
- git pull 후 yarn dev 명령어로 로컬 서버를 실행합니다.
- /intro 페이지에 진입합니다.
- 로그아웃을 합니다
- 채팅 답변 완료 후 로그인 페이지로 이동합니다
- 회원가입 페이지로 이동하여 회원가입 합니다
- (회원 가입 완료 후 로그인 페이지로 리다이렉트)
- 로그인 후 채팅 답변 api 를 호출하는지 확인합니다
