### PR TITLE
생애 콘텐츠 포맷 자동 감지 및 렌더링 통일

### DIFF
--- a/components/detail/Life.tsx
+++ b/components/detail/Life.tsx
@@ -3,13 +3,42 @@ import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
 import Box from "@mui/material/Box";
 import TextAreaCustomized from "./TextAreaCustomized";
-import { useState, ChangeEvent } from "react";
+import { useState, ChangeEvent, useMemo } from "react";
 import Grow from "@mui/material/Grow";
 import { LifeProps } from "./interfaces";
 import { useSession } from "next-auth/react";
 import {decrypt} from "@/utils/cryptUtil";
 import {styled} from "@mui/system";
 import {useRouter} from "next/router";
+import { marked } from "marked";
+
+/** 콘텐츠 포맷 감지: html > markdown > plain text (앱 MemorialBio 동일 로직) */
+function detectFormat(content: string): 'html' | 'markdown' | 'text' {
+	if (!content) return 'text';
+	if (/<[a-z][\s\S]*>/i.test(content)) return 'html';
+
+	const mdPatterns = [
+		/^#{1,6}\s/gm,
+		/\*\*[^*]+\*\*/g,
+		/^[-*]\s/gm,
+		/^\d+\.\s/gm,
+		/\[.+\]\(.+\)/g,
+		/^>/gm,
+		/^---$/gm,
+	];
+	let distinctCount = 0;
+	let hasRepeat = false;
+	for (const p of mdPatterns) {
+		const matches = content.match(p);
+		if (matches) {
+			distinctCount++;
+			if (matches.length >= 2) hasRepeat = true;
+		}
+	}
+	if (distinctCount >= 2 || hasRepeat) return 'markdown';
+
+	return 'text';
+}
 
 const WhiteButton = styled(Button)(() => ({
 	backgroundColor: "white",
@@ -27,6 +56,13 @@ export default function Life({ visitorMessages: initialVisitorMessages, detail, 
 	const [message, setMessage] = useState("");
 	const [isDisabled, setIsDisabled] = useState(false);
 	const router = useRouter();
+
+	const bioFormat = useMemo(() => detectFormat(detail?.career_contents || ''), [detail?.career_contents]);
+	const bioHtml = useMemo(() => {
+		if (!detail?.career_contents) return '';
+		if (bioFormat === 'markdown') return marked.parse(detail.career_contents) as string;
+		return detail.career_contents;
+	}, [detail?.career_contents, bioFormat]);
 
 	const handleButtonClick = (flag: boolean) => {
 		if (!session) {
@@ -91,7 +127,11 @@ export default function Life({ visitorMessages: initialVisitorMessages, detail, 
 				}}
 				className={"diff-card-section"}
 			>
-				{detail && <div style={{ whiteSpace: 'pre-wrap' }} dangerouslySetInnerHTML={{ __html: detail.career_contents }} />}
+				{detail && (
+					bioFormat === 'text'
+						? <div style={{ whiteSpace: 'pre-wrap' }}>{detail.career_contents}</div>
+						: <div style={{ whiteSpace: bioFormat === 'html' ? 'pre-wrap' : undefined }} dangerouslySetInnerHTML={{ __html: bioHtml }} />
+				)}
 			</Container>
 			{session && parseInt(decrypt(session.user_id)) === detail.user_id && (
 				<Box sx={{ display: 'flex', justifyContent: 'end' }}>

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "eslint-config-next": "13.4.19",
     "firebase": "^10.12.2",
     "formidable": "^3.5.4",
+    "marked": "^17.0.3",
     "next": "13.4.19",
     "next-auth": "^4.24.5",
     "react": "18.2.0",
@@ -35,6 +36,7 @@
   },
   "devDependencies": {
     "@types/formidable": "^3.4.5",
+    "@types/marked": "^5.0.2",
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
     "tailwindcss": "3.4.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1077,6 +1077,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/marked@^5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-5.0.2.tgz#ca6b0cd7a5c8799c8cd0963df0b3e1a9021dcdfa"
+  integrity sha512-OucS4KMHhFzhz27KxmWg7J+kIYqyqoW5kdIEI319hqARQQUTqhao3M/F+uFnDXD0Rg72iDDZxZNxq5gvctmLlg==
+
 "@types/node@*":
   version "24.5.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-24.5.2.tgz#52ceb83f50fe0fcfdfbd2a9fab6db2e9e7ef6446"
@@ -3227,6 +3232,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+marked@^17.0.3:
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-17.0.3.tgz#0defa25b1ba288433aa847848475d11109e1b3fd"
+  integrity sha512-jt1v2ObpyOKR8p4XaUJVk3YWRJ5n+i4+rjQopxvV32rSndTJXvIzuUdWWIy/1pFQMkQmvTXawzDNqOH/CUmx6A==
 
 math-intrinsics@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
## 배경

현재 웹에서는 생애(career_contents) 콘텐츠를 항상 `dangerouslySetInnerHTML`로 렌더링하고 있습니다. 
반면 앱에서는 콘텐츠 포맷을 자동 감지(HTML → Markdown → 일반 텍스트)하여 각각 다른 방식으로 렌더링합니다.

이로 인해 마크다운으로 작성된 생애 콘텐츠(예: `## 제목`, `### 소제목`)가 웹에서는 그대로 문자열로 표시되고, 앱에서는 제목 서식으로 표시되는 **플랫폼 간 렌더링 불일치** 문제가 있었습니다.

## 작업 내용

### 1. `marked` 패키지 추가
- 마크다운 → HTML 변환을 위한 경량 라이브러리

### 2. `detectFormat()` 포맷 감지 함수 추가 (`Life.tsx`)
- 앱의 `MemorialBio.tsx`와 동일한 로직 적용
- 감지 우선순위: HTML > Markdown > 일반 텍스트
- 감지 기준:
  - HTML 태그(`<tag>`)가 하나라도 있으면 → **HTML**
  - 마크다운 패턴(제목, 볼드, 리스트, 링크, 인용, 구분선) 2종류 이상 매칭, 또는 **동일 패턴 2회 이상** 매칭 → **Markdown**
  - 그 외 → **일반 텍스트**

### 3. 포맷별 렌더링 분기 (`Life.tsx`)
| 포맷 | 렌더링 방식 |
|------|------------|
| HTML | `dangerouslySetInnerHTML` + `white-space: pre-wrap` (기존과 동일) |
| Markdown | `marked.parse()` → HTML 변환 후 `dangerouslySetInnerHTML` |
| Text | 일반 텍스트 출력 + `white-space: pre-wrap` (innerHTML 미사용) |

## 테스트 방법

1. **마크다운 콘텐츠 확인**: `##`, `###` 제목이 포함된 기념관 상세 페이지에서 제목이 서식 적용되어 표시되는지 확인
   - 예시: `/detail/22` (마크다운 형식 생애 콘텐츠)
2. **HTML 콘텐츠 확인**: HTML 태그가 포함된 기념관에서 기존과 동일하게 렌더링되는지 확인
3. **일반 텍스트 확인**: 서식 없는 일반 텍스트 기념관에서 줄바꿈이 정상 표시되는지 확인
4. **앱과 비교**: 동일한 기념관을 앱에서 열어 웹과 동일하게 렌더링되는지 비교

## 리뷰 노트

- `detectFormat()`는 앱(`MemorialBio.tsx`)과 동일한 로직으로, 향후 한쪽을 수정하면 다른 쪽도 동기화 필요
- 기존 HTML 콘텐츠의 렌더링은 변경 없음 (하위 호환 유지)
- `marked`는 클라이언트 사이드에서만 실행되며, `useMemo`로 불필요한 재파싱 방지
- 일반 텍스트의 경우 `dangerouslySetInnerHTML` 대신 React 텍스트 노드를 사용하여 XSS 위험 제거