### PR TITLE
intro 페이지에 Meta App Links 메타태그 추가 (Android)

### DIFF
--- a/pages/intro.tsx
+++ b/pages/intro.tsx
@@ -1,10 +1,18 @@
 'use client';
 
+import Head from 'next/head';
 import Link from 'next/link';
 
 export default function IntroPage() {
   return (
-    <div className="min-h-screen bg-white">
+    <>
+      <Head>
+        {/* Meta App Links — 페이스북 인앱 브라우저(IAB)가 메모리얼 앱으로 연결되도록 안내 */}
+        <meta property="al:android:url" content="https://yourmemorial.kr/intro" />
+        <meta property="al:android:package" content="kr.yourmemorial.app" />
+        <meta property="al:android:app_name" content="메모리얼" />
+      </Head>
+      <div className="min-h-screen bg-white">
 
       {/* Main Content */}
       <main className="flex-1 flex items-center justify-center min-h-[calc(100vh-80px)]">
@@ -140,5 +148,6 @@ export default function IntroPage() {
         </div>
       </main>
     </div>
+    </>
   );
 }


### PR DESCRIPTION
## 요약

페이스북 광고 클릭 시 페이스북 인앱 브라우저(IAB / WKWebView)에서 메모리얼 앱으로 자동 진입하도록 `al:android:*` 메타태그 3종을 `/intro` 페이지에 추가.

## 배경

페이스북 IAB는 의도적으로 Universal Link / App Link 자동 트리거를 차단합니다 (사용자가 페이스북 안에 머물도록). 이를 우회하는 페이스북 공식 표준이 [Meta App Links 메타태그](https://developers.facebook.com/docs/applinks)입니다. SDK 통합 없이 단순 HTML `<meta>` 태그 4개로 IAB 호환을 확보합니다.

## 변경 사항

- `pages/intro.tsx`: `next/head` import + Fragment로 감싸 `<Head>` 추가, 메타태그 3종 삽입
  - `<meta property="al:android:url" content="https://yourmemorial.kr/intro" />`
  - `<meta property="al:android:package" content="kr.yourmemorial.app" />`
  - `<meta property="al:android:app_name" content="메모리얼" />`

## Non-Goals (이번 PR에서 제외)

- **iOS 메타태그 (`al:ios:*`)** — Apple Developer 계정 미가입 상태. iOS 앱 출시 시 별도 PR로 추가 예정.
- **App Store ID** — iOS 앱 등록 후 `al:ios:app_store_id` 함께 추가.
- **다른 페이지** — 광고 진입은 `/intro` 단일 경로만 사용. 다른 페이지에 추가하지 않음.

## 검증

배포 후 다음으로 확인:

1. **페이스북 Sharing Debugger** — https://developers.facebook.com/tools/debug/
   - 입력: `https://yourmemorial.kr/intro`
   - 결과: "App Links" 섹션에 `al:android:*` 3개 노출되어야 함

2. **페이스북 인앱 브라우저 실제 테스트** (Android 앱 출시 후)
   - 메신저 또는 페이스북 앱 안에서 광고 URL 클릭
   - 화면 상단 또는 별도 배너에 "메모리얼 앱에서 열기" 노출 → 자동 진입

3. **메타태그 직접 확인**
   ```bash
   curl -s https://yourmemorial.kr/intro | grep "al:android"
   ```

## Test plan

- [ ] Vercel/Netlify 자동 배포 후 `view-source:` 또는 curl로 메타태그 노출 확인
- [ ] 페이스북 Sharing Debugger에서 App Links 섹션 인식
- [ ] (Android 앱 출시 + Meta Ads 광고 집행 후) 실제 IAB → 앱 진입 검증

## 비고

- 이 PR은 **memorial-app PR #3 (Universal Links/App Links)** + **memorial-admin-api PR #49 (트래킹 endpoint)** + **PR #50 (대시보드)** 와 함께 동작하는 페이스북 광고 → 앱 진입 시스템의 마지막 클라이언트 측 퍼즐 조각입니다.
- iOS 출시 시 follow-up: `al:ios:url` / `al:ios:app_store_id` / `al:ios:app_name` 추가.