### PR TITLE
Universal Links / App Links 호스팅 인프라 사전 준비 (placeholder)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,4 +9,26 @@ module.exports = {
     };
     return config;
   },
+  async headers() {
+    // Universal Links / App Links 검증 파일에 application/json 응답 헤더 강제.
+    // public/.well-known/apple-app-site-association 는 확장자가 없어
+    // 기본 MIME 추정이 application/octet-stream 이 될 수 있음 → OS가 거부함.
+    // assetlinks.json 도 일관성을 위해 명시.
+    return [
+      {
+        source: '/.well-known/apple-app-site-association',
+        headers: [
+          { key: 'Content-Type', value: 'application/json' },
+          { key: 'Cache-Control', value: 'public, max-age=86400' },
+        ],
+      },
+      {
+        source: '/.well-known/assetlinks.json',
+        headers: [
+          { key: 'Content-Type', value: 'application/json' },
+          { key: 'Cache-Control', value: 'public, max-age=86400' },
+        ],
+      },
+    ];
+  },
 };

--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,21 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "TEAMID0000.kr.yourmemorial.app",
+        "paths": [
+          "/intro",
+          "/intro?*",
+          "/memorial/[0-9]+",
+          "/memorial/[0-9]+?*",
+          "NOT /memorial/edit",
+          "NOT /memorial/create/*",
+          "NOT /admin/*",
+          "NOT /api/*",
+          "NOT /.well-known/*"
+        ]
+      }
+    ]
+  }
+}

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "kr.yourmemorial.app",
+      "sha256_cert_fingerprints": [
+        "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
## 요약

`yourmemorial.kr/.well-known/` 디렉토리 신설 + AASA / assetlinks.json **placeholder** + Next.js Content-Type 헤더 강제.

**식별자(Apple Team ID, Play App Signing SHA256)는 placeholder 상태**라 머지/배포해도 OS verification은 작동 안 함(의도). 추후 계정 가입/앱 등록 후 식별자만 교체하면 즉시 활성화.

## 배경

memorial-app의 딥링크 코드는 이미 100% 준비됨:
- `app.json` `ios.associatedDomains: ["applinks:yourmemorial.kr"]`
- `app.json` `android.intentFilters` autoVerify=true (`/intro`, `/memorial/`)
- `app/intro.tsx` dispatcher + cold/warm 백버튼 흐름

다만 도메인 측 검증 파일이 호스팅 안 돼서 OS가 매칭 불가 (`https://yourmemorial.kr/.well-known/...` → 404). 이 PR이 그 빈자리를 채움.

## 변경 파일

| 파일 | 신규/수정 | 역할 |
|---|---|---|
| `public/.well-known/assetlinks.json` | 신규 | Android App Links 검증. sha256 fingerprint는 `00:00:...` placeholder |
| `public/.well-known/apple-app-site-association` | 신규 | iOS Universal Links 검증. **확장자 없음**. appID의 `TEAMID0000`은 placeholder. paths는 정밀화 적용(`/memorial/[0-9]+`, NOT 제외) |
| `next.config.js` | 수정 | `async headers()` 추가 — 두 파일에 `Content-Type: application/json` 강제 + 1일 Cache-Control |

## 왜 `next.config.js` headers()가 필수인가

`apple-app-site-association`은 **확장자 없는 파일**. Next.js 13.4의 `public/` 정적 서빙은 확장자로 MIME을 추정하므로 확장자 없는 파일은 `application/octet-stream`으로 응답할 가능성. iOS는 `application/json`이 아닌 응답을 거부함 → Universal Link 작동 X.

`headers()`로 두 파일 모두 `Content-Type: application/json` 명시.

## 활성화 절차 (Trigger 발생 시)

### Android (Trigger A — Play 본인 인증 + 앱 등록 + AAB 업로드 후)
1. Play Console → Setup → App signing → SHA-256 certificate fingerprint 복사
2. `public/.well-known/assetlinks.json`의 `00:...` 32회를 실제 값으로 교체
3. 새 PR → 머지 → 운영 배포
4. 검증: `curl https://digitalassetlinks.googleapis.com/v1/statements:list?source.web.site=https://yourmemorial.kr&relation=delegate_permission/common.handle_all_urls`

### iOS (Trigger B — Apple Developer 가입 후)
1. Apple Developer Account → Membership Details → Team ID 복사 (10자)
2. `public/.well-known/apple-app-site-association`의 `TEAMID0000`을 실제 값으로 교체
3. 새 PR → 머지 → 운영 배포
4. Apple CDN 캐시(24h~7일) 대기. Stage 1 (canary `/intro`만) → Stage 2 (full path) 단계적 권장

## 검증 (이번 PR)

- ✅ JSON 두 파일 jq 파싱 통과
- ✅ `next.config.js` node로 require OK
- ⏳ 머지 + 운영 배포 후:
  - `curl -I https://yourmemorial.kr/.well-known/apple-app-site-association` → 200 + `Content-Type: application/json`
  - `curl -I https://yourmemorial.kr/.well-known/assetlinks.json` → 동일

## 보안 / 운영 영향

- placeholder 식별자라 OS verification 실패가 의도된 동작 — 사용자가 https URL 클릭 시 그냥 웹브라우저로 열림 (현재와 동일)
- 식별자 노출은 보안 문제 X (이 파일들은 publicly readable이 정의됨)
- 활성화 후엔 캐시(24h) 때문에 변경 즉시 반영 안 될 수 있음 — 첫 배포 시 Stage 1/2 권장

## 관련

- 활성화 절차 상세: `memorial-app/.omc/plans/universal-links-rollout-plan.md`
- 모태: `memorial-app/.omc/plans/fb-ads-deeplink-plan.md` External-3 항목
- 관련 PR: memorial-app #3 (Universal Links 코드), Memorial #39 (al:android:* 메타태그)